### PR TITLE
fix(server): add missing hono dependency

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "hono": "^4.12.26",
         "jsonwebtoken": "^9.0.3"
       },
       "devDependencies": {
@@ -2053,6 +2054,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/http-errors": {

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "hono": "^4.12.26",
     "jsonwebtoken": "^9.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## What
Adds `hono` to `server/package.json`.

## Why
The deployed Cloudflare Worker imports `hono` in every route file (`worker.ts`, `routes/*.worker.ts`), but the package was never listed as a dependency. Running `wrangler dev` from `server/` fails with 7 `Could not resolve "hono"` errors, blocking local backend development.

## Test
`cd server && wrangler dev` now boots cleanly. endpoint returns `{"status":"ok"}`.