### PR TITLE
chore: local dev workflow + dev-mode auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.*
 # local env files
 .env*.local
 .env
+.dev.vars
 
 # Cloudflare
 .wrangler/

--- a/app/config/api.ts
+++ b/app/config/api.ts
@@ -1,3 +1,17 @@
-// Base URL for the Cloudflare Worker API
-// Update this when deploying to a custom domain
-export const API_BASE_URL = "https://loop-db.longhorn-developers.workers.dev";
+// Where the app sends its API calls.
+//
+// In dev (Expo running on a simulator on your Mac), we hit the local
+// Worker you start with `wrangler dev` in the server folder.
+// In a real build, we hit the deployed Cloudflare Worker.
+//
+// If you test on a real phone with Expo Go, "localhost" won't reach
+// your Mac. Either replace LOCAL_API with your Mac's LAN IP, or set
+// EXPO_PUBLIC_API_BASE_URL to override.
+
+const PROD_API = 'https://loop-db.longhorn-developers.workers.dev';
+const LOCAL_API = 'http://localhost:8787';
+
+const override = process.env.EXPO_PUBLIC_API_BASE_URL;
+
+export const API_BASE_URL =
+  override ?? (__DEV__ ? LOCAL_API : PROD_API);

--- a/server/.dev.vars.example
+++ b/server/.dev.vars.example
@@ -1,0 +1,14 @@
+# Local secrets for `wrangler dev`. Copy to .dev.vars and fill in.
+# .dev.vars is git-ignored; .dev.vars.example is the template.
+
+# Used to sign JWT tokens. Any string works for local dev.
+JWT_SECRET=local-dev-jwt-secret-change-me
+
+# Resend API key. Only needed if RESEND_DEV_MODE != "true".
+# Get one at https://resend.com (free tier OK).
+RESEND_API_KEY=
+
+# When "true", the Worker logs verification codes to the console instead of
+# emailing them. Lets you test signup locally without a verified Resend
+# domain. Never set this in production.
+RESEND_DEV_MODE=true

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,69 @@
+# Longhorn Loop — Server
+
+Cloudflare Worker backend (Hono + D1). Deployed at
+`loop-db.longhorn-developers.workers.dev` in production.
+
+## Local setup
+
+Works on macOS, Linux, and Windows — anywhere Node + Wrangler run.
+
+```bash
+cd server
+npm install
+cp .dev.vars.example .dev.vars   # defaults work for local dev
+npx wrangler d1 execute loop-db --local --file=schema.sql
+npx wrangler dev
+```
+
+Worker is now running at `http://localhost:8787`. The app's
+`app/config/api.ts` already points there when running in dev mode, so
+`npx expo start` in the repo root will use it automatically.
+
+### Seed events
+
+```bash
+curl -X POST http://localhost:8787/events/scrape \
+  -H "Content-Type: application/json" \
+  -d '{"maxPages":3}'
+```
+
+Pulls ~60 events from HornsLink into your local D1.
+
+## Secrets
+
+- `.dev.vars` — used by `wrangler dev`. Git-ignored. Copy `.dev.vars.example` to start.
+- `.dev.vars.example` — template, committed.
+- Production secrets — set via `wrangler secret put NAME` (needs Cloudflare access).
+
+### `RESEND_DEV_MODE`
+
+When `RESEND_DEV_MODE=true`, `/auth/send-code` prints the verification
+code to the wrangler console instead of calling Resend. Useful because
+Resend's free tier only allows sending to one verified inbox, which
+makes signup hard to test as a team.
+
+To test signup locally:
+
+1. Have `RESEND_DEV_MODE=true` in `.dev.vars`
+2. Sign up in the app with any email
+3. Look at the wrangler terminal — you'll see a line like:
+   ```
+   [DEV] Verification code for you@example.com: 123456
+   ```
+4. Paste that code into the verification screen
+
+Never set `RESEND_DEV_MODE` in production.
+
+## Useful commands
+
+```bash
+# inspect local D1
+npx wrangler d1 execute loop-db --local --command="SELECT * FROM events LIMIT 5"
+
+# wipe and re-seed local D1
+npx wrangler d1 execute loop-db --local --command="DROP TABLE IF EXISTS events"
+npx wrangler d1 execute loop-db --local --file=schema.sql
+
+# tail prod Worker logs (needs Cloudflare access)
+npx wrangler tail
+```

--- a/server/src/routes/auth.worker.ts
+++ b/server/src/routes/auth.worker.ts
@@ -25,6 +25,24 @@ function isValidUTEmail(email: string): boolean {
   return email.toLowerCase().endsWith("@utexas.edu");
 }
 
+// Decide how to deliver the verification code. In dev mode we just log it
+// so devs can test signup without a verified Resend domain. Otherwise we
+// call Resend.
+async function deliverVerificationCode(
+  to: string,
+  code: string,
+  env: Env,
+): Promise<void> {
+  if (env.RESEND_DEV_MODE === "true") {
+    console.log(
+      `\n[DEV] Verification code for ${to}: ${code}\n` +
+        `      (RESEND_DEV_MODE=true — skipping Resend)\n`,
+    );
+    return;
+  }
+  await sendVerificationEmail(to, code, env.RESEND_API_KEY);
+}
+
 // Send verification email via Resend
 async function sendVerificationEmail(
   to: string,
@@ -109,7 +127,7 @@ authRoutes.post("/send-code", async (c) => {
     .run();
 
   // Send verification email
-  await sendVerificationEmail(normalizedEmail, code, c.env.RESEND_API_KEY);
+  await deliverVerificationCode(normalizedEmail, code, c.env);
 
   return c.json({ message: "VERIFICATION_CODE_SENT" });
 });
@@ -230,7 +248,7 @@ authRoutes.post("/resend-code", async (c) => {
     .run();
 
   // Send verification email
-  await sendVerificationEmail(normalizedEmail, code, c.env.RESEND_API_KEY);
+  await deliverVerificationCode(normalizedEmail, code, c.env);
 
   return c.json({ message: "VERIFICATION_CODE_SENT" });
 });

--- a/server/src/worker.ts
+++ b/server/src/worker.ts
@@ -13,6 +13,10 @@ export type Env = {
   DB: D1Database;
   JWT_SECRET: string;
   RESEND_API_KEY: string;
+  // When set to "true" in .dev.vars, the Worker logs verification codes to
+  // the wrangler console instead of sending them through Resend. Never set
+  // in production.
+  RESEND_DEV_MODE?: string;
 };
 
 const app = new Hono<{ Bindings: Env }>();


### PR DESCRIPTION
## What
Makes local backend development possible for everyone on the team. Unblocks signup testing without needing the Resend dashboard or a verified domain.

### `RESEND_DEV_MODE` in `server/src/routes/auth.worker.ts`
When set to `"true"` in `.dev.vars`, `/auth/send-code` logs the verification code to the wrangler terminal instead of calling Resend. Lets any dev test signup locally without sharing the Resend account or verifying a custom domain. Never set in production.

### `app/config/api.ts`
Picks the API URL based on the runtime:
- `__DEV__` → `http://localhost:8787` (local Worker)
- Production build → deployed Worker
- `EXPO_PUBLIC_API_BASE_URL` overrides both

### `server/.dev.vars.example` + `server/README.md`
Template + docs so a new contributor can spin up the backend in under a minute.

### `.gitignore`
Adds `.dev.vars` so real secrets stay local.

## How a teammate uses this

```bash
git pull
cd server
npm install
cp .dev.vars.example .dev.vars   # defaults are dev-mode, no real keys needed
npx wrangler d1 execute loop-db --local --file=schema.sql
npx wrangler dev
```

Then in another terminal, `npx expo start` from the repo root. Signup → code prints in wrangler terminal → paste → done.

## Test
1. Pull branch, follow the README setup steps
2. `curl -X POST http://localhost:8787/auth/send-code -H "Content-Type: application/json" -d '{"email":"any@example.com"}'`
3. Wrangler terminal shows `[DEV] Verification code for any@example.com: 123456`
4. App points at localhost in dev, hits the deployed Worker in production builds