### PR TITLE
fix: restore shared EventCard import on home

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -1,8 +1,6 @@
 import BellIcon from '@/assets/images/bell.svg';
-import BookmarkIcon from '@/assets/images/bookmark.svg';
 import HookemIcon from '@/assets/images/hookem.svg';
-import LocationIcon from '@/assets/images/location.svg';
-import VerifiedIcon from '@/assets/images/verified.svg';
+import EventCard, { ApiEvent } from '@/app/components/EventCard';
 import { API_BASE_URL } from '@/app/config/api';
 import { useOnboarding } from '@/app/context/OnboardingContext';
 import { useRouter } from 'expo-router';
@@ -10,7 +8,6 @@ import React, { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
-  Image,
   ScrollView,
   Text,
   TouchableOpacity,
@@ -18,169 +15,11 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-// ---------- Types ----------
-
-interface ApiEvent {
-  id: number;
-  source: string;
-  source_event_id: string;
-  title: string;
-  description: string | null;
-  start_datetime: string;
-  end_datetime: string | null;
-  location_short: string | null;
-  location_full: string | null;
-  host_organization_id: number;
-  host_organization_name: string;
-  event_url: string | null;
-  image_url: string | null;
-  image_aspect_ratio: string | null;
-  theme: string | null;
-  visibility: string;
-  rsvp_total: number;
-  org_profile_picture: string | null;
-  categories: { id: string; name: string }[];
-  benefits: string[];
-}
-
-// ---------- Helpers ----------
-
-/**
- * Format ISO datetime to "Fri, 4/29 • 6:00 PM"
- */
-function formatEventDate(isoString: string): string {
-  const date = new Date(isoString);
-  const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-  const day = days[date.getDay()];
-  const month = date.getMonth() + 1;
-  const dayNum = date.getDate();
-
-  let hours = date.getHours();
-  const minutes = date.getMinutes();
-  const ampm = hours >= 12 ? 'PM' : 'AM';
-  hours = hours % 12 || 12;
-  const timeStr = minutes === 0 ? `${hours}:00 ${ampm}` : `${hours}:${minutes.toString().padStart(2, '0')} ${ampm}`;
-
-  return `${day}, ${month}/${dayNum} • ${timeStr}`;
-}
-
-/**
- * Get a greeting based on time of day
- */
 function getGreeting(): string {
   const hour = new Date().getHours();
   if (hour < 12) return 'Good morning,';
   if (hour < 17) return 'Good afternoon,';
   return 'Good evening,';
-}
-
-// ---------- Components ----------
-
-function EventCard({
-  item,
-  isSaved,
-  onToggleSave,
-}: {
-  item: ApiEvent;
-  isSaved: boolean;
-  onToggleSave: (eventId: number) => void;
-}) {
-  const hasImage = !!item.image_url;
-  const hasBenefits = item.benefits && item.benefits.length > 0;
-
-  return (
-    <View style={{ width: 180 }} className="mr-4 rounded-2xl overflow-hidden bg-white border border-lhlGrey">
-      {/* Image area */}
-      <View style={{ backgroundColor: '#D9D9D9', height: 160 }} className="w-full">
-        {hasImage && (
-          <Image
-            source={{ uri: item.image_url! }}
-            style={{ width: '100%', height: '100%' }}
-            resizeMode="cover"
-          />
-        )}
-
-        {/* Benefits badge (e.g., Free Food) */}
-        {hasBenefits && (
-          <View
-            style={{
-              position: 'absolute',
-              bottom: 8,
-              left: 8,
-              backgroundColor: '#BF5700',
-              borderRadius: 12,
-              paddingHorizontal: 8,
-              paddingVertical: 3,
-            }}
-          >
-            <Text style={{ color: '#fff', fontSize: 10, fontWeight: '600' }}>
-              {item.benefits[0]}
-            </Text>
-          </View>
-        )}
-
-        {/* Bookmark button */}
-        <TouchableOpacity
-          onPress={() => onToggleSave(item.id)}
-          style={{
-            position: 'absolute',
-            top: 10,
-            right: 10,
-            backgroundColor: 'white',
-            borderRadius: 999,
-            width: 34,
-            height: 34,
-            alignItems: 'center',
-            justifyContent: 'center',
-            shadowColor: '#000',
-            shadowOpacity: 0.15,
-            shadowRadius: 4,
-            elevation: 3,
-          }}
-        >
-          <BookmarkIcon width={10} height={14} color={isSaved ? '#BF5700' : '#020B12'} />
-        </TouchableOpacity>
-      </View>
-
-      {/* Card Info */}
-      <View style={{ padding: 12 }}>
-        {/* Title */}
-        <Text
-          style={{ fontSize: 14, fontWeight: '700', color: '#020B12', marginBottom: 2 }}
-          numberOfLines={1}
-        >
-          {item.title}
-        </Text>
-
-        {/* Posted by + org profile pic */}
-        <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 4 }}>
-          {item.org_profile_picture && (
-            <Image
-              source={{ uri: item.org_profile_picture }}
-              style={{ width: 14, height: 14, borderRadius: 7, marginRight: 4 }}
-            />
-          )}
-          <Text style={{ fontSize: 12, color: '#020B12', flex: 1 }} numberOfLines={1}>
-            {item.host_organization_name}
-          </Text>
-          <VerifiedIcon width={16} height={16} style={{ marginLeft: 4, flexShrink: 0 }} />
-        </View>
-
-        {/* Date */}
-        <Text style={{ fontSize: 12, color: '#9A9A9A', marginBottom: 4 }}>
-          {formatEventDate(item.start_datetime)}
-        </Text>
-
-        {/* Location */}
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
-          <LocationIcon width={14} height={14} />
-          <Text style={{ fontSize: 12, color: '#9A9A9A' }} numberOfLines={1}>
-            {item.location_short || 'TBD'}
-          </Text>
-        </View>
-      </View>
-    </View>
-  );
 }
 
 function CarouselSection({


### PR DESCRIPTION
## What
Home screen now imports the shared `EventCard` component again, restoring tap-to-detail navigation.

## Why
The shared component was introduced in #261. A later merge conflict resolution (commit d62ba89) silently rolled it back, replacing the import with an inline copy of EventCard that had no `Pressable` wrapper. Result: tapping event cards on home did nothing.

This swaps the inline copy out for the import that was lost.

## Test
Open the app, tap any event card on home → event detail screen opens.