### PR TITLE
feat: report event flow

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -3,8 +3,8 @@ import HookemIcon from '@/assets/images/hookem.svg';
 import EventCard, { ApiEvent } from '@/app/components/EventCard';
 import { API_BASE_URL } from '@/app/config/api';
 import { useOnboarding } from '@/app/context/OnboardingContext';
-import { useRouter } from 'expo-router';
-import React, { useEffect, useState } from 'react';
+import { useFocusEffect, useRouter } from 'expo-router';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -103,6 +103,15 @@ export default function HomeScreen() {
     if (token) fetchSavedIds();
   }, [token]);
 
+  // Re-fetch whenever the home tab regains focus. Keeps the feed fresh after
+  // mutations on other screens (RSVP, save, report).
+  useFocusEffect(
+    useCallback(() => {
+      fetchEvents();
+      if (token) fetchSavedIds();
+    }, [token]),
+  );
+
   const fetchSavedIds = async () => {
     try {
       const res = await fetch(`${API_BASE_URL}/saved`, {
@@ -150,12 +159,14 @@ export default function HomeScreen() {
 
   const fetchEvents = async () => {
     try {
-      // Fetch multiple sections in parallel
+      // Send the auth header so the backend can hide events this user has
+      // reported (in addition to the global threshold filter).
+      const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
       const [upcomingRes, freeFoodRes, socialRes, academicRes] = await Promise.all([
-        fetch(`${API_BASE_URL}/events?limit=10`),
-        fetch(`${API_BASE_URL}/events?limit=10&benefit=Free Food`),
-        fetch(`${API_BASE_URL}/events?limit=10&theme=Social`),
-        fetch(`${API_BASE_URL}/events?limit=10&category=Academic`),
+        fetch(`${API_BASE_URL}/events?limit=10`, { headers }),
+        fetch(`${API_BASE_URL}/events?limit=10&benefit=Free Food`, { headers }),
+        fetch(`${API_BASE_URL}/events?limit=10&theme=Social`, { headers }),
+        fetch(`${API_BASE_URL}/events?limit=10&category=Academic`, { headers }),
       ]);
 
       const [upcomingData, freeFoodData, socialData, academicData] = await Promise.all([

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,8 +21,10 @@ export default function RootLayout() {
         {/* Main tabs — disable swipe back to prevent returning to onboarding */}
         <Stack.Screen name="(tabs)" options={{ gestureEnabled: false }} />
 
-        {/* Event detail */}
-        <Stack.Screen name="event/[id]" />
+        {/* Event detail + nested screens */}
+        <Stack.Screen name="event/[id]/index" />
+        <Stack.Screen name="event/[id]/report" />
+        <Stack.Screen name="event/[id]/report-success" />
       </Stack>
 
       {!splashDone && <SplashScreen onFinish={() => setSplashDone(true)} />}

--- a/app/event/[id]/index.tsx
+++ b/app/event/[id]/index.tsx
@@ -412,8 +412,10 @@ export default function EventDetailScreen() {
           <Text style={styles.sectionHeader}>Attendees</Text>
           <AttendeesRow />
 
-          {/* TODO: wire up reporting flow. */}
-          <TouchableOpacity disabled style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+          <TouchableOpacity
+            onPress={() => router.push(`/event/${id}/report`)}
+            style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
+          >
             <FlagIcon width={12} height={14} />
             <Text style={{ color: REPORT_RED, fontSize: 14, fontWeight: '600' }}>
               Report this event

--- a/app/event/[id]/report-success.tsx
+++ b/app/event/[id]/report-success.tsx
@@ -1,0 +1,79 @@
+// Shown after a successful report submission. Confirms receipt and gives
+// the user a clean "Return Home" exit (instead of leaving them on the
+// event they just reported, which is now hidden for them anyway).
+
+import { useRouter } from 'expo-router';
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+const BG = '#F9F8F5';
+const BURNT_ORANGE = '#BF5700';
+const TEXT_PRIMARY = '#020B12';
+
+export default function ReportSuccessScreen() {
+  const router = useRouter();
+
+  const goHome = () => router.replace('/(tabs)/home');
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: BG }}>
+      <View style={styles.container}>
+        <View style={styles.checkCircle}>
+          <Text style={styles.checkMark}>✓</Text>
+        </View>
+
+        <Text style={styles.body}>
+          We appreciate your report and will review this event soon!
+        </Text>
+
+        <Pressable onPress={goHome} style={styles.button}>
+          <Text style={styles.buttonText}>RETURN HOME</Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = {
+  container: {
+    flex: 1,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    paddingHorizontal: 32,
+  },
+  checkCircle: {
+    width: 88,
+    height: 88,
+    borderRadius: 44,
+    backgroundColor: BURNT_ORANGE,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    marginBottom: 32,
+  },
+  checkMark: {
+    color: '#fff',
+    fontSize: 44,
+    fontWeight: '700' as const,
+    lineHeight: 48,
+  },
+  body: {
+    fontSize: 18,
+    color: TEXT_PRIMARY,
+    textAlign: 'center' as const,
+    lineHeight: 26,
+    marginBottom: 40,
+  },
+  button: {
+    backgroundColor: BURNT_ORANGE,
+    paddingHorizontal: 32,
+    paddingVertical: 14,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700' as const,
+    letterSpacing: 1,
+  },
+};

--- a/app/event/[id]/report.tsx
+++ b/app/event/[id]/report.tsx
@@ -1,0 +1,308 @@
+// Report event screen. Reached from "Report this event" on the event
+// detail screen.
+//
+// Layout follows Figma (Report frame): off-white background, title,
+// four reason checkboxes (multi-select), required description textarea,
+// submit button that turns orange once both fields are valid.
+//
+// On submit:
+//   - POST /events/:id/report with { reasons: string[], description: string }
+//   - navigate to /event/[id]/report-success on success
+//   - show inline red banner if validation fails
+
+import ArrowLeftIcon from '@/assets/images/arrow-left.svg';
+import { API_BASE_URL } from '@/app/config/api';
+import { useOnboarding } from '@/app/context/OnboardingContext';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useState } from 'react';
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+const BG = '#F9F8F5';
+const TEXT_PRIMARY = '#020B12';
+const TEXT_MUTED = '#485656';
+const BORDER = 'rgba(0,0,0,0.20)';
+const BURNT_ORANGE = '#BF5700';
+const ERROR_RED = '#B30404';
+const ERROR_BG = '#FCE4E4';
+
+type ReasonCode = 'violent_harmful' | 'misinformation' | 'troll_spam' | 'other';
+
+const REASONS: { code: ReasonCode; label: string }[] = [
+  { code: 'violent_harmful', label: 'This event is violent / harmful' },
+  { code: 'misinformation', label: 'This event contains misinformation' },
+  { code: 'troll_spam', label: 'This event is a troll / spam' },
+  { code: 'other', label: 'Concern not listed' },
+];
+
+export default function ReportEventScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const { data: onboarding } = useOnboarding();
+  const token = onboarding.token;
+
+  const [selectedReasons, setSelectedReasons] = useState<Set<ReasonCode>>(
+    new Set(),
+  );
+  const [description, setDescription] = useState('');
+  const [showError, setShowError] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const isValid =
+    selectedReasons.size > 0 && description.trim().length > 0;
+
+  const toggleReason = (code: ReasonCode) => {
+    setShowError(false);
+    setSelectedReasons((prev) => {
+      const next = new Set(prev);
+      if (next.has(code)) next.delete(code);
+      else next.add(code);
+      return next;
+    });
+  };
+
+  const handleSubmit = async () => {
+    if (!isValid) {
+      setShowError(true);
+      return;
+    }
+    if (!token) {
+      setShowError(true);
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${API_BASE_URL}/events/${id}/report`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          reasons: Array.from(selectedReasons),
+          description: description.trim(),
+        }),
+      });
+      if (!res.ok) {
+        console.error('Report failed:', await res.text());
+        setShowError(true);
+        return;
+      }
+      router.replace(`/event/${id}/report-success`);
+    } catch (err) {
+      console.error('Report request failed:', err);
+      setShowError(true);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: BG }} edges={['top']}>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        {/* Back */}
+        <View style={{ paddingHorizontal: 24, paddingTop: 8 }}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={16}>
+            <ArrowLeftIcon width={24} height={24} />
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView
+          contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 120 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Title */}
+          <Text style={styles.title}>Why are you reporting this event?</Text>
+
+          {showError && (
+            <View style={styles.errorBanner}>
+              <Text style={styles.errorText}>
+                Please fill out all of the required fields.
+              </Text>
+            </View>
+          )}
+
+          {/* Reason checkboxes */}
+          <View style={{ marginTop: 16, gap: 16 }}>
+            {REASONS.map((r) => {
+              const checked = selectedReasons.has(r.code);
+              return (
+                <Pressable
+                  key={r.code}
+                  onPress={() => toggleReason(r.code)}
+                  style={styles.checkboxRow}
+                >
+                  <View
+                    style={[
+                      styles.checkbox,
+                      checked && styles.checkboxChecked,
+                    ]}
+                  >
+                    {checked && <Text style={styles.checkboxMark}>✓</Text>}
+                  </View>
+                  <Text
+                    style={[
+                      styles.reasonLabel,
+                      checked && { color: BURNT_ORANGE, fontWeight: '600' },
+                    ]}
+                  >
+                    {r.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          {/* Tell us more */}
+          <Text style={[styles.title, { marginTop: 32 }]}>Tell us more:</Text>
+
+          <View style={styles.textareaWrapper}>
+            <TextInput
+              value={description}
+              onChangeText={(t) => {
+                setDescription(t);
+                setShowError(false);
+              }}
+              placeholder="Description (required)"
+              placeholderTextColor={TEXT_MUTED}
+              multiline
+              textAlignVertical="top"
+              style={styles.textarea}
+            />
+          </View>
+        </ScrollView>
+
+        {/* Submit */}
+        <View style={styles.submitWrapper}>
+          <Pressable
+            onPress={handleSubmit}
+            disabled={submitting}
+            style={[
+              styles.submitButton,
+              isValid ? styles.submitButtonActive : styles.submitButtonDisabled,
+            ]}
+          >
+            <Text
+              style={[
+                styles.submitText,
+                isValid ? styles.submitTextActive : styles.submitTextDisabled,
+              ]}
+            >
+              {submitting ? 'Submitting…' : 'Submit report'}
+            </Text>
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = {
+  title: {
+    fontSize: 24,
+    fontWeight: '700' as const,
+    color: '#000',
+    marginTop: 24,
+  },
+  errorBanner: {
+    marginTop: 16,
+    backgroundColor: ERROR_BG,
+    borderColor: ERROR_RED,
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+  },
+  errorText: {
+    color: ERROR_RED,
+    fontSize: 14,
+    fontWeight: '500' as const,
+  },
+  checkboxRow: {
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
+    gap: 16,
+  },
+  checkbox: {
+    width: 18,
+    height: 18,
+    borderRadius: 3,
+    borderWidth: 1,
+    borderColor: BORDER,
+    backgroundColor: '#fff',
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+  },
+  checkboxChecked: {
+    backgroundColor: BURNT_ORANGE,
+    borderColor: BURNT_ORANGE,
+  },
+  checkboxMark: {
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: '700' as const,
+    lineHeight: 14,
+  },
+  reasonLabel: {
+    flex: 1,
+    fontSize: 16,
+    color: TEXT_PRIMARY,
+  },
+  textareaWrapper: {
+    marginTop: 16,
+    height: 182,
+    backgroundColor: '#fff',
+    borderRadius: 8,
+    borderColor: BORDER,
+    borderWidth: 1,
+    padding: 12,
+  },
+  textarea: {
+    flex: 1,
+    fontSize: 16,
+    color: TEXT_PRIMARY,
+  },
+  submitWrapper: {
+    paddingHorizontal: 20,
+    paddingBottom: 24,
+    paddingTop: 8,
+    backgroundColor: BG,
+  },
+  submitButton: {
+    borderRadius: 8,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    paddingVertical: 14,
+  },
+  submitButtonDisabled: {
+    backgroundColor: '#fff',
+    borderWidth: 2,
+    borderColor: BORDER,
+  },
+  submitButtonActive: {
+    backgroundColor: BURNT_ORANGE,
+  },
+  submitText: {
+    fontSize: 20,
+    fontWeight: '500' as const,
+  },
+  submitTextDisabled: {
+    color: TEXT_MUTED,
+  },
+  submitTextActive: {
+    color: '#fff',
+    fontWeight: '600' as const,
+  },
+};

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -137,3 +137,18 @@ CREATE TABLE IF NOT EXISTS notifications (
   read_at TEXT,
   created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+-- Event reports -- user-submitted moderation reports. Once an event has
+-- REPORT_HIDE_THRESHOLD (5) reports it is filtered from feeds for everyone.
+-- The reporter also stops seeing it immediately regardless of the count.
+CREATE TABLE IF NOT EXISTS event_reports (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  reasons TEXT NOT NULL,        -- JSON array of reason codes
+  description TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(user_id, event_id)     -- one report per user per event
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_reports_event ON event_reports(event_id);

--- a/server/src/routes/events.worker.ts
+++ b/server/src/routes/events.worker.ts
@@ -5,6 +5,85 @@ import { scrapeHornsLink } from "../scrapers/hornslink";
 
 export const eventRoutes = new Hono<{ Bindings: Env }>();
 
+// Once an event has this many reports it's filtered from feeds globally.
+const REPORT_HIDE_THRESHOLD = 5;
+
+const REPORT_REASONS = new Set([
+  "violent_harmful",
+  "misinformation",
+  "troll_spam",
+  "other",
+]);
+
+// JWT verification (mirrors the pattern used in saved.worker.ts).
+async function getAuthUser(
+  authHeader: string | undefined,
+  secret: string,
+): Promise<{ email: string } | null> {
+  if (!authHeader || !authHeader.startsWith("Bearer ")) return null;
+  const token = authHeader.split(" ")[1];
+  try {
+    const [headerB64, payloadB64, sigB64] = token.split(".");
+    const encoder = new TextEncoder();
+    const signingInput = `${headerB64}.${payloadB64}`;
+    const key = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["verify"],
+    );
+    const sigBytes = Uint8Array.from(atob(sigB64), (c) => c.charCodeAt(0));
+    const valid = await crypto.subtle.verify(
+      "HMAC",
+      key,
+      sigBytes,
+      encoder.encode(signingInput),
+    );
+    if (!valid) return null;
+    const payload = JSON.parse(atob(payloadB64));
+    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
+    return { email: payload.email };
+  } catch {
+    return null;
+  }
+}
+
+async function getUserId(
+  db: D1Database,
+  email: string,
+): Promise<number | null> {
+  const row = await db
+    .prepare("SELECT id FROM users WHERE email = ?")
+    .bind(email)
+    .first();
+  return row ? (row.id as number) : null;
+}
+
+// Returns a SQL fragment + params that hide events the caller already
+// reported and any event over the global threshold.
+function buildVisibilityFilter(userId: number | null): {
+  sql: string;
+  params: any[];
+} {
+  const params: any[] = [REPORT_HIDE_THRESHOLD];
+  let sql = `
+    AND (
+      SELECT COUNT(*) FROM event_reports er WHERE er.event_id = e.id
+    ) < ?
+  `;
+  if (userId !== null) {
+    sql += `
+      AND NOT EXISTS (
+        SELECT 1 FROM event_reports er2
+        WHERE er2.event_id = e.id AND er2.user_id = ?
+      )
+    `;
+    params.push(userId);
+  }
+  return { sql, params };
+}
+
 // GET /events -- list upcoming events with optional filters
 eventRoutes.get("/", async (c) => {
   const limit = parseInt(c.req.query("limit") || "20");
@@ -14,14 +93,24 @@ eventRoutes.get("/", async (c) => {
   const theme = c.req.query("theme");
   const orgId = c.req.query("orgId");
 
+  // If the caller is signed in, also hide events they've already reported.
+  // Anonymous callers only get the global threshold filter.
+  const auth = await getAuthUser(
+    c.req.header("Authorization"),
+    c.env.JWT_SECRET,
+  );
+  const userId = auth ? await getUserId(c.env.DB, auth.email) : null;
+  const visibility = buildVisibilityFilter(userId);
+
   let query = `
     SELECT e.*, o.profile_picture as org_profile_picture
     FROM events e
     LEFT JOIN organizations o ON e.host_organization_id = o.id
     WHERE e.status = 'active'
       AND e.end_datetime > datetime('now')
+      ${visibility.sql}
   `;
-  const params: any[] = [];
+  const params: any[] = [...visibility.params];
 
   if (theme) {
     query += ` AND e.theme = ?`;
@@ -87,6 +176,12 @@ eventRoutes.get("/", async (c) => {
 eventRoutes.get("/:id", async (c) => {
   const id = c.req.param("id");
 
+  const auth = await getAuthUser(
+    c.req.header("Authorization"),
+    c.env.JWT_SECRET,
+  );
+  const userId = auth ? await getUserId(c.env.DB, auth.email) : null;
+
   const event = await c.env.DB.prepare(
     `SELECT e.*, o.profile_picture as org_profile_picture
      FROM events e
@@ -98,6 +193,27 @@ eventRoutes.get("/:id", async (c) => {
 
   if (!event) {
     return c.json({ error: "EVENT_NOT_FOUND" }, 404);
+  }
+
+  // Hide events the caller already reported, or that crossed the global
+  // report threshold. Treat as not-found so the UI handles it cleanly.
+  const reportCount = await c.env.DB.prepare(
+    "SELECT COUNT(*) as c FROM event_reports WHERE event_id = ?",
+  )
+    .bind(id)
+    .first();
+  if (reportCount && (reportCount.c as number) >= REPORT_HIDE_THRESHOLD) {
+    return c.json({ error: "EVENT_NOT_FOUND" }, 404);
+  }
+  if (userId !== null) {
+    const reportedByMe = await c.env.DB.prepare(
+      "SELECT 1 FROM event_reports WHERE event_id = ? AND user_id = ?",
+    )
+      .bind(id, userId)
+      .first();
+    if (reportedByMe) {
+      return c.json({ error: "EVENT_NOT_FOUND" }, 404);
+    }
   }
 
   const categories = await c.env.DB.prepare(
@@ -120,6 +236,72 @@ eventRoutes.get("/:id", async (c) => {
     })),
     benefits: benefits.results.map((b: any) => b.benefit_name),
   });
+});
+
+// POST /events/:id/report -- user reports an event for moderation.
+// Body: { reasons: string[], description: string }
+// At REPORT_HIDE_THRESHOLD reports, the event is hidden from every feed.
+eventRoutes.post("/:id/report", async (c) => {
+  const auth = await getAuthUser(
+    c.req.header("Authorization"),
+    c.env.JWT_SECRET,
+  );
+  if (!auth) return c.json({ error: "UNAUTHORIZED" }, 401);
+
+  const userId = await getUserId(c.env.DB, auth.email);
+  if (!userId) return c.json({ error: "USER_NOT_FOUND" }, 401);
+
+  const eventId = parseInt(c.req.param("id"));
+  if (!Number.isFinite(eventId)) {
+    return c.json({ error: "INVALID_EVENT_ID" }, 400);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const reasons: unknown = (body as any).reasons;
+  const description: unknown = (body as any).description;
+
+  if (!Array.isArray(reasons) || reasons.length === 0) {
+    return c.json({ error: "MISSING_REASONS" }, 400);
+  }
+  if (typeof description !== "string" || description.trim().length === 0) {
+    return c.json({ error: "MISSING_DESCRIPTION" }, 400);
+  }
+  const cleanReasons = reasons.filter(
+    (r): r is string => typeof r === "string" && REPORT_REASONS.has(r),
+  );
+  if (cleanReasons.length === 0) {
+    return c.json({ error: "INVALID_REASONS" }, 400);
+  }
+
+  // Confirm the event exists before recording the report.
+  const eventExists = await c.env.DB.prepare(
+    "SELECT 1 FROM events WHERE id = ?",
+  )
+    .bind(eventId)
+    .first();
+  if (!eventExists) return c.json({ error: "EVENT_NOT_FOUND" }, 404);
+
+  try {
+    await c.env.DB.prepare(
+      `INSERT INTO event_reports (user_id, event_id, reasons, description)
+       VALUES (?, ?, ?, ?)`,
+    )
+      .bind(
+        userId,
+        eventId,
+        JSON.stringify(cleanReasons),
+        description.trim(),
+      )
+      .run();
+  } catch (err) {
+    // unique(user_id, event_id) -- ignore duplicate reports
+    if (String(err).includes("UNIQUE")) {
+      return c.json({ ok: true, alreadyReported: true });
+    }
+    throw err;
+  }
+
+  return c.json({ ok: true });
 });
 
 // POST /events/scrape -- manually trigger a scrape (for testing)


### PR DESCRIPTION
## What
Adds the report-event flow end-to-end.

### Backend
- `event_reports` table in `schema.sql` (unique per user+event)
- `POST /events/:id/report` (auth-gated): validates reasons + description, writes to D1
- `GET /events` and `GET /events/:id` filter out:
  - events the caller has personally reported (auth-aware)
  - events with ≥ 5 total reports (global threshold)

### Frontend
- `app/event/[id]/report.tsx` — multi-select reason checkboxes, required description, red error banner on empty submit, orange Submit when valid
- `app/event/[id]/report-success.tsx` — orange check + Return Home
- Detail screen "Report this event" link wired up
- Home re-fetches on focus and sends auth so reported events disappear from the feed immediately

### File restructure
- `app/event/[id].tsx` → `app/event/[id]/index.tsx` so `report.tsx` and `report-success.tsx` can be siblings
- Stack registrations updated in `_layout.tsx`

## Test
1. `wrangler dev` + `expo start`
2. Sign up (you need to finish onboarding so the user row gets created)
3. Tap an event card → Report this event → fill the form → Submit
4. Success screen → Return Home → reported event is gone from carousels
5. Hit the same event from 4 more accounts → it disappears for everyone

## Out of scope (follow-ups)
- Migrate fetch hooks to React Query
- Untrack `server/.wrangler/` from git (it's gitignored but historically tracked)