### PR TITLE
chore: set up React Query (provider, query keys, api helper)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,33 +1,48 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack } from 'expo-router';
 import { useState } from 'react';
 import SplashScreen from './components/SplashScreen';
 import { OnboardingProvider } from './context/OnboardingContext';
 
+// One QueryClient for the whole app. 30s staleTime means same-key queries
+// won't refetch within 30s of the last fetch. Mutations still force fresh
+// data via queryClient.invalidateQueries().
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      retry: 1,
+    },
+  },
+});
+
 export default function RootLayout() {
   const [splashDone, setSplashDone] = useState(false);
 
   return (
-    <OnboardingProvider>
-      <Stack screenOptions={{ headerShown: false }}>
-        {/* Entry: FrontPage */}
-        <Stack.Screen name="index" />
+    <QueryClientProvider client={queryClient}>
+      <OnboardingProvider>
+        <Stack screenOptions={{ headerShown: false }}>
+          {/* Entry: FrontPage */}
+          <Stack.Screen name="index" />
 
-        {/* Auth flow */}
-        <Stack.Screen name="(auth)" />
+          {/* Auth flow */}
+          <Stack.Screen name="(auth)" />
 
-        {/* Onboarding flow */}
-        <Stack.Screen name="(onboarding)" />
+          {/* Onboarding flow */}
+          <Stack.Screen name="(onboarding)" />
 
-        {/* Main tabs — disable swipe back to prevent returning to onboarding */}
-        <Stack.Screen name="(tabs)" options={{ gestureEnabled: false }} />
+          {/* Main tabs — disable swipe back to prevent returning to onboarding */}
+          <Stack.Screen name="(tabs)" options={{ gestureEnabled: false }} />
 
-        {/* Event detail + nested screens */}
-        <Stack.Screen name="event/[id]/index" />
-        <Stack.Screen name="event/[id]/report" />
-        <Stack.Screen name="event/[id]/report-success" />
-      </Stack>
+          {/* Event detail + nested screens */}
+          <Stack.Screen name="event/[id]/index" />
+          <Stack.Screen name="event/[id]/report" />
+          <Stack.Screen name="event/[id]/report-success" />
+        </Stack>
 
-      {!splashDone && <SplashScreen onFinish={() => setSplashDone(true)} />}
-    </OnboardingProvider>
+        {!splashDone && <SplashScreen onFinish={() => setSplashDone(true)} />}
+      </OnboardingProvider>
+    </QueryClientProvider>
   );
 }

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1,0 +1,73 @@
+// Thin wrapper around fetch() so query/mutation functions don't repeat
+// the auth-header + JSON-parsing + error-throwing dance.
+//
+// Use this from inside React Query's `queryFn` / `mutationFn`:
+//
+//   useQuery({
+//     queryKey: events.list(),
+//     queryFn: () => api.get<EventsResponse>('/events', { token }),
+//   });
+
+import { API_BASE_URL } from '@/app/config/api';
+
+export class ApiError extends Error {
+  status: number;
+  body: unknown;
+  constructor(status: number, body: unknown, message: string) {
+    super(message);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+interface RequestOptions {
+  token?: string | null;
+  body?: unknown;
+  signal?: AbortSignal;
+}
+
+async function request<T>(
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+  path: string,
+  opts: RequestOptions = {},
+): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (opts.token) headers['Authorization'] = `Bearer ${opts.token}`;
+
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    signal: opts.signal,
+  });
+
+  // Try to parse JSON, but tolerate empty bodies / non-JSON errors.
+  let parsed: unknown = null;
+  const text = await res.text();
+  if (text) {
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = text;
+    }
+  }
+
+  if (!res.ok) {
+    const message =
+      (parsed && typeof parsed === 'object' && 'error' in parsed
+        ? String((parsed as Record<string, unknown>).error)
+        : null) ?? `HTTP ${res.status}`;
+    throw new ApiError(res.status, parsed, message);
+  }
+
+  return parsed as T;
+}
+
+export const api = {
+  get: <T>(path: string, opts?: RequestOptions) => request<T>('GET', path, opts),
+  post: <T>(path: string, opts?: RequestOptions) => request<T>('POST', path, opts),
+  put: <T>(path: string, opts?: RequestOptions) => request<T>('PUT', path, opts),
+  patch: <T>(path: string, opts?: RequestOptions) => request<T>('PATCH', path, opts),
+  delete: <T>(path: string, opts?: RequestOptions) => request<T>('DELETE', path, opts),
+};

--- a/app/lib/queryKeys.ts
+++ b/app/lib/queryKeys.ts
@@ -1,0 +1,24 @@
+// Centralized React Query keys so screens stay consistent.
+//
+// Each "domain" is a function that returns a tuple. The hierarchy lets
+// `queryClient.invalidateQueries({ queryKey: events.all })` invalidate
+// every events-related query at once.
+
+export const events = {
+  all: ['events'] as const,
+  lists: () => [...events.all, 'list'] as const,
+  list: (params: Record<string, string | undefined> = {}) =>
+    [...events.lists(), params] as const,
+  details: () => [...events.all, 'detail'] as const,
+  detail: (id: string | number) => [...events.details(), String(id)] as const,
+};
+
+export const saved = {
+  all: ['saved'] as const,
+  list: () => [...saved.all, 'list'] as const,
+};
+
+export const notifications = {
+  all: ['notifications'] as const,
+  list: () => [...notifications.all, 'list'] as const,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
+        "@tanstack/react-query": "^5.101.2",
+        "@tanstack/react-query-devtools": "^5.101.2",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
@@ -3400,6 +3402,59 @@
       },
       "peerDependencies": {
         "@svgr/core": "*"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.2.tgz",
+      "integrity": "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.101.2.tgz",
+      "integrity": "sha512-o+wHcqgN7Pp0s8v1i0UGq/ZrrEKrxdIiMQmKRdYb2w7NPtylYSJ4+wg/tIn71m9DLstwUwdEGAvROdly6HXP6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.2.tgz",
+      "integrity": "sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.101.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.101.2.tgz",
+      "integrity": "sha512-eU7HctdA9gDjqoERoEdzLbw9DiqnBDfh5+Hu0u26gjqoHJezOpQAuiesDL2VvkU+2cPV76zgv0tMZsOrI4LjnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.101.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.101.2",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "@tanstack/react-query": "^5.101.2",
+    "@tanstack/react-query-devtools": "^5.101.2",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",


### PR DESCRIPTION
## What
Setup-only PR. Installs React Query, wires the provider, adds shared helpers. No screens migrated yet.

### Added
- `@tanstack/react-query` dependency
- `<QueryClientProvider>` in `app/_layout.tsx` (30s staleTime, 1 retry)
- `app/lib/queryKeys.ts` — central query keys
- `app/lib/api.ts` — thin fetch wrapper with auth + JSON + error helpers

### Not changed
No existing screen behavior. PR 2 will migrate home, event detail, and report screen.

## Test
Pull, run the app. Everything behaves identically. The library is just sitting there waiting for the next PR.