### PR TITLE
refactor: migrate home, detail, and report to React Query

### DIFF
--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -1,10 +1,16 @@
 import BellIcon from '@/assets/images/bell.svg';
 import HookemIcon from '@/assets/images/hookem.svg';
 import EventCard, { ApiEvent } from '@/app/components/EventCard';
-import { API_BASE_URL } from '@/app/config/api';
 import { useOnboarding } from '@/app/context/OnboardingContext';
-import { useFocusEffect, useRouter } from 'expo-router';
-import React, { useCallback, useEffect, useState } from 'react';
+import { api } from '@/app/lib/api';
+import { events as eventsKeys, saved as savedKeys } from '@/app/lib/queryKeys';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import { useRouter } from 'expo-router';
+import React from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -20,6 +26,26 @@ function getGreeting(): string {
   if (hour < 12) return 'Good morning,';
   if (hour < 17) return 'Good afternoon,';
   return 'Good evening,';
+}
+
+// Shape the events list endpoint returns.
+type EventsListResponse = { events: ApiEvent[] };
+type SavedListResponse = { events: ApiEvent[] };
+
+// Tiny helper: fetch one carousel's worth of events.
+function eventListQueryOptions(
+  filterKey: string,
+  search: string,
+  token: string | null,
+) {
+  return {
+    queryKey: eventsKeys.list({ filter: filterKey }),
+    queryFn: () =>
+      api.get<EventsListResponse>(`/events?${search}`, { token }),
+    // Use a slightly longer staleTime so the four carousels don't re-fire
+    // back-to-back. They still refetch on focus.
+    staleTime: 30_000,
+  };
 }
 
 function CarouselSection({
@@ -82,110 +108,97 @@ function CarouselSection({
   );
 }
 
-// ---------- Main Screen ----------
-
 export default function HomeScreen() {
   const router = useRouter();
   const { data } = useOnboarding();
-  const token = data.token;
-  const [upcoming, setUpcoming] = useState<ApiEvent[]>([]);
-  const [freeFood, setFreeFood] = useState<ApiEvent[]>([]);
-  const [social, setSocial] = useState<ApiEvent[]>([]);
-  const [academic, setAcademic] = useState<ApiEvent[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [savedIds, setSavedIds] = useState<Set<number>>(new Set());
+  const token = data.token || null;
+  const queryClient = useQueryClient();
 
-  useEffect(() => {
-    fetchEvents();
-  }, []);
-
-  useEffect(() => {
-    if (token) fetchSavedIds();
-  }, [token]);
-
-  // Re-fetch whenever the home tab regains focus. Keeps the feed fresh after
-  // mutations on other screens (RSVP, save, report).
-  useFocusEffect(
-    useCallback(() => {
-      fetchEvents();
-      if (token) fetchSavedIds();
-    }, [token]),
+  // Four event carousels — each its own query so they cache independently.
+  const upcomingQuery = useQuery(
+    eventListQueryOptions('upcoming', 'limit=10', token),
+  );
+  const freeFoodQuery = useQuery(
+    eventListQueryOptions('free-food', 'limit=10&benefit=Free Food', token),
+  );
+  const socialQuery = useQuery(
+    eventListQueryOptions('social', 'limit=10&theme=Social', token),
+  );
+  const academicQuery = useQuery(
+    eventListQueryOptions('academic', 'limit=10&category=Academic', token),
   );
 
-  const fetchSavedIds = async () => {
-    try {
-      const res = await fetch(`${API_BASE_URL}/saved`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const result = await res.json();
-      if (res.ok && Array.isArray(result.events)) {
-        setSavedIds(new Set(result.events.map((e: ApiEvent) => e.id)));
+  // Saved IDs — only run when signed in.
+  const savedQuery = useQuery({
+    queryKey: savedKeys.list(),
+    queryFn: () => api.get<SavedListResponse>('/saved', { token }),
+    enabled: !!token,
+  });
+
+  const savedIds = React.useMemo(
+    () => new Set((savedQuery.data?.events ?? []).map((e) => e.id)),
+    [savedQuery.data],
+  );
+
+  // Toggle save with optimistic UI. onMutate flips the cache instantly,
+  // onError rolls back, onSettled re-fetches to sync with the server.
+  const toggleSave = useMutation({
+    mutationFn: async ({
+      eventId,
+      wasSaved,
+    }: {
+      eventId: number;
+      wasSaved: boolean;
+    }) => {
+      if (wasSaved) {
+        await api.delete(`/saved/${eventId}`, { token });
+      } else {
+        await api.post(`/saved/${eventId}`, { token });
       }
-    } catch (err) {
-      console.error('Failed to fetch saved events:', err);
-    }
-  };
+    },
+    onMutate: async ({ eventId, wasSaved }) => {
+      await queryClient.cancelQueries({ queryKey: savedKeys.list() });
+      const previous = queryClient.getQueryData<SavedListResponse>(
+        savedKeys.list(),
+      );
+      queryClient.setQueryData<SavedListResponse>(
+        savedKeys.list(),
+        (old) => {
+          const list = old?.events ?? [];
+          if (wasSaved) {
+            return { events: list.filter((e) => e.id !== eventId) };
+          }
+          // We don't have the full event here; the placeholder shape is fine
+          // for membership checks until onSettled re-fetches the real list.
+          return {
+            events: [...list, { id: eventId } as ApiEvent],
+          };
+        },
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(savedKeys.list(), context.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: savedKeys.list() });
+    },
+  });
 
-  const handleToggleSave = async (eventId: number) => {
+  const handleToggleSave = (eventId: number) => {
     if (!token) return;
-
-    const wasSaved = savedIds.has(eventId);
-
-    // Optimistic update
-    setSavedIds((prev) => {
-      const next = new Set(prev);
-      if (wasSaved) next.delete(eventId);
-      else next.add(eventId);
-      return next;
-    });
-
-    try {
-      const res = await fetch(`${API_BASE_URL}/saved/${eventId}`, {
-        method: wasSaved ? 'DELETE' : 'POST',
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error('Request failed');
-    } catch (err) {
-      console.error('Failed to toggle saved event:', err);
-      // Revert on failure
-      setSavedIds((prev) => {
-        const next = new Set(prev);
-        if (wasSaved) next.add(eventId);
-        else next.delete(eventId);
-        return next;
-      });
-    }
+    toggleSave.mutate({ eventId, wasSaved: savedIds.has(eventId) });
   };
 
-  const fetchEvents = async () => {
-    try {
-      // Send the auth header so the backend can hide events this user has
-      // reported (in addition to the global threshold filter).
-      const headers = token ? { Authorization: `Bearer ${token}` } : undefined;
-      const [upcomingRes, freeFoodRes, socialRes, academicRes] = await Promise.all([
-        fetch(`${API_BASE_URL}/events?limit=10`, { headers }),
-        fetch(`${API_BASE_URL}/events?limit=10&benefit=Free Food`, { headers }),
-        fetch(`${API_BASE_URL}/events?limit=10&theme=Social`, { headers }),
-        fetch(`${API_BASE_URL}/events?limit=10&category=Academic`, { headers }),
-      ]);
-
-      const [upcomingData, freeFoodData, socialData, academicData] = await Promise.all([
-        upcomingRes.json(),
-        freeFoodRes.json(),
-        socialRes.json(),
-        academicRes.json(),
-      ]);
-
-      setUpcoming(upcomingData.events || []);
-      setFreeFood(freeFoodData.events || []);
-      setSocial(socialData.events || []);
-      setAcademic(academicData.events || []);
-    } catch (err) {
-      console.error('Failed to fetch events:', err);
-    } finally {
-      setLoading(false);
-    }
-  };
+  // While any carousel is on its first fetch we show the loader; subsequent
+  // background refetches are silent.
+  const loading =
+    upcomingQuery.isPending ||
+    freeFoodQuery.isPending ||
+    socialQuery.isPending ||
+    academicQuery.isPending;
 
   return (
     <SafeAreaView className="flex-1 bg-lhlBackgroundColor" edges={['left', 'right']}>
@@ -242,31 +255,30 @@ export default function HomeScreen() {
           style={{ height: 1, backgroundColor: '#D2DEE0', marginHorizontal: 20, marginBottom: 24 }}
         />
 
-        {/* Event Carousels — real data from API */}
         <CarouselSection
           title="Upcoming"
-          data={upcoming}
+          data={upcomingQuery.data?.events ?? []}
           loading={loading}
           savedIds={savedIds}
           onToggleSave={handleToggleSave}
         />
         <CarouselSection
           title="Free Food"
-          data={freeFood}
+          data={freeFoodQuery.data?.events ?? []}
           loading={loading}
           savedIds={savedIds}
           onToggleSave={handleToggleSave}
         />
         <CarouselSection
           title="Social"
-          data={social}
+          data={socialQuery.data?.events ?? []}
           loading={loading}
           savedIds={savedIds}
           onToggleSave={handleToggleSave}
         />
         <CarouselSection
           title="Academic"
-          data={academic}
+          data={academicQuery.data?.events ?? []}
           loading={loading}
           savedIds={savedIds}
           onToggleSave={handleToggleSave}

--- a/app/event/[id]/index.tsx
+++ b/app/event/[id]/index.tsx
@@ -12,9 +12,15 @@ import ShareIcon from '@/assets/images/share.svg';
 import { ApiEvent } from '@/app/components/EventCard';
 import ConfirmModal from '@/app/components/rsvp/ConfirmModal';
 import RsvpSuccessToast from '@/app/components/rsvp/RsvpSuccessToast';
-import { API_BASE_URL } from '@/app/config/api';
 import { useOnboarding } from '@/app/context/OnboardingContext';
+import { api, ApiError } from '@/app/lib/api';
+import { events as eventsKeys, saved as savedKeys } from '@/app/lib/queryKeys';
 import { addRsvp, isRsvped as isRsvpedInStore, removeRsvp } from '@/app/lib/rsvpStore';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import React, { useEffect, useState } from 'react';
@@ -158,86 +164,94 @@ function AttendeesRow() {
   );
 }
 
+type SavedListResponse = { events: ApiEvent[] };
+
 export default function EventDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const { data: onboarding } = useOnboarding();
-  const token = onboarding.token;
+  const token = onboarding.token || null;
+  const queryClient = useQueryClient();
 
-  const [event, setEvent] = useState<ApiEvent | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isSaved, setIsSaved] = useState(false);
-
-  // RSVP state — local-only for now, persisted via AsyncStorage in rsvpStore.
+  // RSVP UI state stays local — it's not server data.
   const [isRsvped, setIsRsvped] = useState(false);
   const [showOpenLinkModal, setShowOpenLinkModal] = useState(false);
   const [showDidYouRsvpModal, setShowDidYouRsvpModal] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [showToast, setShowToast] = useState(false);
 
-  useEffect(() => {
-    if (!id) return;
-    fetchEvent();
-  }, [id]);
+  // Fetch the event.
+  const eventQuery = useQuery({
+    queryKey: eventsKeys.detail(id!),
+    queryFn: () => api.get<ApiEvent>(`/events/${id}`, { token }),
+    enabled: !!id,
+  });
 
-  useEffect(() => {
-    if (token && id) checkIfSaved();
-  }, [token, id]);
+  // Fetch saved IDs so we can show the correct bookmark state.
+  const savedQuery = useQuery({
+    queryKey: savedKeys.list(),
+    queryFn: () => api.get<SavedListResponse>('/saved', { token }),
+    enabled: !!token,
+  });
+
+  const event = eventQuery.data ?? null;
+  const isSaved = React.useMemo(() => {
+    const list = savedQuery.data?.events ?? [];
+    return list.some((e) => String(e.id) === String(id));
+  }, [savedQuery.data, id]);
+
+  // Optimistic toggle save.
+  const toggleSave = useMutation({
+    mutationFn: async (wasSaved: boolean) => {
+      if (!event) return;
+      if (wasSaved) {
+        await api.delete(`/saved/${event.id}`, { token });
+      } else {
+        await api.post(`/saved/${event.id}`, { token });
+      }
+    },
+    onMutate: async (wasSaved) => {
+      if (!event) return;
+      await queryClient.cancelQueries({ queryKey: savedKeys.list() });
+      const previous = queryClient.getQueryData<SavedListResponse>(
+        savedKeys.list(),
+      );
+      queryClient.setQueryData<SavedListResponse>(savedKeys.list(), (old) => {
+        const list = old?.events ?? [];
+        if (wasSaved) {
+          return { events: list.filter((e) => e.id !== event.id) };
+        }
+        return { events: [...list, { id: event.id } as ApiEvent] };
+      });
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(savedKeys.list(), context.previous);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: savedKeys.list() });
+    },
+  });
+
+  const handleToggleSave = () => {
+    if (!token || !event) return;
+    toggleSave.mutate(isSaved);
+  };
 
   useEffect(() => {
     if (!id) return;
     isRsvpedInStore(Number(id)).then(setIsRsvped);
   }, [id]);
 
-  const fetchEvent = async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch(`${API_BASE_URL}/events/${id}`);
-      if (!res.ok) {
-        setError(res.status === 404 ? 'This event could not be found.' : 'Something went wrong loading this event.');
-        return;
-      }
-      setEvent(await res.json());
-    } catch (err) {
-      console.error('Failed to fetch event:', err);
-      setError('Could not load event. Check your connection and try again.');
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const checkIfSaved = async () => {
-    try {
-      const res = await fetch(`${API_BASE_URL}/saved`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) return;
-      const result = await res.json();
-      if (Array.isArray(result.events)) {
-        setIsSaved(result.events.some((e: ApiEvent) => String(e.id) === String(id)));
-      }
-    } catch (err) {
-      console.error('Failed to check saved state:', err);
-    }
-  };
-
-  const handleToggleSave = async () => {
-    if (!token || !event) return;
-    const wasSaved = isSaved;
-    setIsSaved(!wasSaved);
-    try {
-      const res = await fetch(`${API_BASE_URL}/saved/${event.id}`, {
-        method: wasSaved ? 'DELETE' : 'POST',
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error('Request failed');
-    } catch (err) {
-      console.error('Failed to toggle saved event:', err);
-      setIsSaved(wasSaved);
-    }
-  };
+  // Map the query state to the existing loading / error / event UI.
+  const loading = eventQuery.isPending;
+  const error = eventQuery.isError
+    ? eventQuery.error instanceof ApiError && eventQuery.error.status === 404
+      ? 'This event could not be found.'
+      : 'Something went wrong loading this event.'
+    : null;
 
   // Top-level entry point for the RSVP button. Branches on current state
   // and whether the event has a dedicated rsvp_url.

--- a/app/event/[id]/report.tsx
+++ b/app/event/[id]/report.tsx
@@ -11,8 +11,10 @@
 //   - show inline red banner if validation fails
 
 import ArrowLeftIcon from '@/assets/images/arrow-left.svg';
-import { API_BASE_URL } from '@/app/config/api';
 import { useOnboarding } from '@/app/context/OnboardingContext';
+import { api } from '@/app/lib/api';
+import { events as eventsKeys } from '@/app/lib/queryKeys';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useState } from 'react';
 import {
@@ -48,14 +50,14 @@ export default function ReportEventScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const { data: onboarding } = useOnboarding();
-  const token = onboarding.token;
+  const token = onboarding.token || null;
+  const queryClient = useQueryClient();
 
   const [selectedReasons, setSelectedReasons] = useState<Set<ReasonCode>>(
     new Set(),
   );
   const [description, setDescription] = useState('');
   const [showError, setShowError] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
 
   const isValid =
     selectedReasons.size > 0 && description.trim().length > 0;
@@ -70,40 +72,37 @@ export default function ReportEventScreen() {
     });
   };
 
-  const handleSubmit = async () => {
-    if (!isValid) {
-      setShowError(true);
-      return;
-    }
-    if (!token) {
-      setShowError(true);
-      return;
-    }
-    setSubmitting(true);
-    try {
-      const res = await fetch(`${API_BASE_URL}/events/${id}/report`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({
+  const submitReport = useMutation({
+    mutationFn: () =>
+      api.post(`/events/${id}/report`, {
+        token,
+        body: {
           reasons: Array.from(selectedReasons),
           description: description.trim(),
-        }),
-      });
-      if (!res.ok) {
-        console.error('Report failed:', await res.text());
-        setShowError(true);
-        return;
-      }
+        },
+      }),
+    onSuccess: () => {
+      // The reported event is filtered out of /events list queries, so
+      // refresh the home carousels. Detail-screen queries don't need
+      // refetching: each detail screen the user already viewed will
+      // 404 if they revisit it, which is the correct behavior.
+      queryClient.invalidateQueries({ queryKey: eventsKeys.lists() });
       router.replace(`/event/${id}/report-success`);
-    } catch (err) {
+    },
+    onError: (err) => {
       console.error('Report request failed:', err);
       setShowError(true);
-    } finally {
-      setSubmitting(false);
+    },
+  });
+
+  const submitting = submitReport.isPending;
+
+  const handleSubmit = () => {
+    if (!isValid || !token) {
+      setShowError(true);
+      return;
     }
+    submitReport.mutate();
   };
 
   return (


### PR DESCRIPTION
## What
Migrates the three biggest screens off raw `fetch` + `useState` + `useEffect` to React Query.

### Home (`app/(tabs)/home.tsx`)
- Four event carousels → four `useQuery` calls (cached independently, refetch on focus built-in)
- Saved IDs now uses  one `useQuery` shared across the app
- Toggle save now uses`useMutation` with optimistic update + rollback

### Event detail (`app/event/[id]/index.tsx`)
- Event fetch + saved-state lookup now makes two `useQuery` calls
- Same cache as home -> if home loaded saved IDs, detail uses them for free, no extra request
- Toggle save -> `useMutation` with optimistic update + rollback
- 404 error message now uses the typed `ApiError` from `lib/api.ts`

### Report (`app/event/[id]/report.tsx`)
- Submit -> `useMutation`
- On success: invalidate `events.lists()` so home carousels drop the reported event immediately

## Big plus for this migration
Six things we get for free now:
- Refetch-on-focus is built in (no more hand-rolled `useFocusEffect`)
- Same data shared across screens is fetched once
- Mutations have proper optimistic + rollback patterns
- Race conditions during rapid taps are handled
- One config place (`staleTime: 30s`) controls request frequency
- Adding new mutations elsewhere becomes one `useMutation` instead of repeating the same try/catch/rollback dance

## Test
1. Home → cards load, bookmark toggle flips instantly
2. Tap a card → detail loads, bookmark state stays consistent with home
3. Toggle bookmark on detail → home reflects the change when you swipe back
4. Tap "Report this event" → submit → reported event disappears from home carousels
5. Wrangler logs show no wasted detail-screen refetches after a report

## Follow-ups (logged)
- Migrate notifications screen + the rest of the saved tab when those screens get backend wiring
- Add React Query DevTools panel in dev builds