### PR TITLE
feat(scraper): scrape McCombs Events calendar (LOOP-147)

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -29,6 +29,17 @@ curl -X POST http://localhost:8787/events/scrape \
 
 Pulls ~60 events from HornsLink into your local D1.
 
+```bash
+curl -X POST http://localhost:8787/events/scrape/mccombs \
+  -H "Content-Type: application/json" \
+  -d '{"dryRun":true}'
+```
+
+Scrapes McCombs events (`calendar.mccombs.utexas.edu`). Pass `"dryRun":true`
+to log what would be written without touching D1, or omit it (or set
+`false`) to upsert for real. `maxEvents` caps how many events are processed
+(default 500).
+
 ## Secrets
 
 - `.dev.vars` — used by `wrangler dev`. Git-ignored. Copy `.dev.vars.example` to start.

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc",
     "start": "node dist/index.js"

--- a/server/src/routes/events.worker.ts
+++ b/server/src/routes/events.worker.ts
@@ -1,7 +1,8 @@
 // Events routes for Cloudflare Worker
-import { Hono } from 'hono';
-import type { Env } from '../worker';
-import { scrapeHornsLink } from '../scrapers/hornslink';
+import { Hono } from "hono";
+import { scrapeHornsLink } from "../scrapers/hornslink";
+import { scrapeMccombs } from "../scrapers/mccombs";
+import type { Env } from "../worker";
 
 export const eventRoutes = new Hono<{ Bindings: Env }>();
 
@@ -280,6 +281,17 @@ eventRoutes.post('/scrape', async (c) => {
   const dryRun = (body as any).dryRun ?? false;
 
   const result = await scrapeHornsLink(c.env.DB, { maxPages, dryRun });
+
+  return c.json(result);
+});
+
+// POST /events/scrape/mccombs -- manually trigger the McCombs scrape (for testing)
+eventRoutes.post("/scrape/mccombs", async (c) => {
+  const body = await c.req.json().catch(() => ({}));
+  const maxEvents = (body as any).maxEvents ?? 500;
+  const dryRun = (body as any).dryRun ?? false;
+
+  const result = await scrapeMccombs(c.env.DB, { maxEvents, dryRun });
 
   return c.json(result);
 });

--- a/server/src/scrapers/__fixtures__/mccombs/external-registration.html
+++ b/server/src/scrapers/__fixtures__/mccombs/external-registration.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8"/>
+	<title>McCombs+ Partner Info Session / Events Calendar - McCombs School of Business</title>
+	<script type="application/ld+json">
+	/*<![CDATA[*/
+	{
+		"@context": "http://schema.org/",
+		"@type": "Event",
+		"eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+		"name": "McCombs+ Partner Info Session",
+		"startDate": "2026-07-10T17:00:00+00:00",
+		"endDate": "2026-07-10T18:00:00+00:00",
+		"eventStatus": "https://schema.org/EventScheduled",
+		"url": "https://calendar.mccombs.utexas.edu/mccombsplus/event/10977-mccombs-partner-info-session",
+		"description": "  Join the McCombs+ Experiential Learning team for a virtual introduction to our program.    Register at https://www.eventbrite.com/e/mccombs-partner-info-session-123456789. ",
+		"location": [
+			{
+				"@type": "Place",
+				"name": "Virtual Event",
+				"address": {
+					"@type": "PostalAddress",
+					"streetAddress": "Virtual Event"
+				}
+			}
+		],
+		"organizer": {
+			"@type": "Organization",
+			"name": "McCombs+ (McCombs School of Business - The University of Texas at Austin)",
+			"url": "https://calendar.mccombs.utexas.edu/mccombsplus/"
+		}
+	}
+	/*]]>*/
+	</script>
+</head>
+<body></body>
+</html>

--- a/server/src/scrapers/__fixtures__/mccombs/no-flyer.html
+++ b/server/src/scrapers/__fixtures__/mccombs/no-flyer.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8"/>
+	<title>Global Sustainability Leadership Institute Info Session / Events Calendar - McCombs School of Business</title>
+	<script type="application/ld+json">
+	/*<![CDATA[*/
+	{
+		"@context": "http://schema.org/",
+		"@type": "Event",
+		"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+		"name": "Global Sustainability Leadership Institute Information Session + Mixer",
+		"startDate": "2026-08-25T22:30:00+00:00",
+		"endDate": "2026-08-25T22:30:00+00:00",
+		"eventStatus": "https://schema.org/EventScheduled",
+		"url": "https://calendar.mccombs.utexas.edu/gsli/event/11401-global-sustainability-leadership-institute",
+		"description": "Welcome to the Forty Acres, Longhorns! Join us for a brief information session about our offerings, then stay for a mixer for students interested in sustainability.",
+		"location": [
+			{
+				"@type": "Place",
+				"name": "CBA 3.302",
+				"address": {
+					"@type": "PostalAddress",
+					"streetAddress": "CBA 3.302"
+				}
+			}
+		],
+		"organizer": {
+			"@type": "Organization",
+			"name": "Global Sustainability Leadership Institute (McCombs School of Business - The University of Texas at Austin)",
+			"url": "https://calendar.mccombs.utexas.edu/gsli/"
+		}
+	}
+	/*]]>*/
+	</script>
+</head>
+<body></body>
+</html>

--- a/server/src/scrapers/__fixtures__/mccombs/rsvp-required.html
+++ b/server/src/scrapers/__fixtures__/mccombs/rsvp-required.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8"/>
+	<title>Herb Kelleher Center Speaker Series / Events Calendar - McCombs School of Business</title>
+	<script type="application/ld+json">
+	/*<![CDATA[*/
+	{
+		"@context": "http://schema.org/",
+		"@type": "Event",
+		"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+		"name": "Herb Kelleher Center Speaker Series: Leading Through Change",
+		"startDate": "2026-10-02T19:00:00+00:00",
+		"endDate": "2026-10-02T20:30:00+00:00",
+		"eventStatus": "https://schema.org/EventScheduled",
+		"url": "https://calendar.mccombs.utexas.edu/kelleher/event/12045-speaker-series-leading-through-change",
+		"description": "  Space is limited &amp; RSVP required to attend. Please arrive 15 minutes early for check-in. ",
+		"location": [
+			{
+				"@type": "Place",
+				"name": "AT&amp;T Hotel &amp; Conference Center, 1900 University Ave, Austin, TX 78705",
+				"address": {
+					"@type": "PostalAddress",
+					"streetAddress": "AT&amp;T Hotel &amp; Conference Center, 1900 University Ave, Austin, TX 78705"
+				}
+			}
+		],
+		"organizer": {
+			"@type": "Organization",
+			"name": "Herb Kelleher Center (McCombs School of Business - The University of Texas at Austin)",
+			"url": "https://calendar.mccombs.utexas.edu/kelleher/"
+		}
+	}
+	/*]]>*/
+	</script>
+</head>
+<body></body>
+</html>

--- a/server/src/scrapers/__fixtures__/mccombs/standard.html
+++ b/server/src/scrapers/__fixtures__/mccombs/standard.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8"/>
+	<title>MSITM Lunch and Learn: Data Careers / Events Calendar - McCombs School of Business</title>
+	<script type="application/ld+json">
+	/*<![CDATA[*/
+	{
+		"@context": "http://schema.org/",
+		"@type": "Event",
+		"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+		"name": "MSITM Lunch and Learn: Data Careers",
+		"startDate": "2026-09-15T17:00:00+00:00",
+		"endDate": "2026-09-15T18:00:00+00:00",
+		"eventStatus": "https://schema.org/EventScheduled",
+		"url": "https://calendar.mccombs.utexas.edu/msitm/event/12001-msitm-lunch-and-learn-data-careers",
+		"description": "  Join MSITM faculty and alumni for a panel on breaking into data careers.    Lunch will be provided. ",
+		"location": [
+			{
+				"@type": "Place",
+				"name": "GSB 2.122, 2110 Speedway, Austin, TX 78705",
+				"address": {
+					"@type": "PostalAddress",
+					"streetAddress": "GSB 2.122, 2110 Speedway, Austin, TX 78705"
+				}
+			}
+		],
+		"image": {
+			"@type": "ImageObject",
+			"url": "https://calendar.mccombs.utexas.edu/live/image/gid/9/width/600/height/600/crop/1/src_region/0,0,1200,800/lunch-and-learn-flyer.jpg",
+			"width": 0,
+			"height": 0
+		},
+		"organizer": {
+			"@type": "Organization",
+			"name": "MSITM (McCombs School of Business - The University of Texas at Austin)",
+			"url": "https://calendar.mccombs.utexas.edu/msitm/"
+		}
+	}
+	/*]]>*/
+	</script>
+</head>
+<body></body>
+</html>

--- a/server/src/scrapers/mccombs.test.ts
+++ b/server/src/scrapers/mccombs.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  buildLocationFull,
+  buildLocationShort,
+  classifyAspectRatio,
+  cleanHostOrganization,
+  decodeHtmlEntities,
+  extractLocs,
+  extractRsvpUrl,
+  extractSourceEventId,
+  parseEventFromHtml,
+  parseImageDimensions,
+  upgradeImageUrl,
+} from "./mccombs";
+
+function loadFixture(name: string): string {
+  return readFileSync(join(__dirname, "__fixtures__", "mccombs", name), "utf-8");
+}
+
+describe("parseEventFromHtml", () => {
+  it("parses a standard event with a flyer image", () => {
+    const parsed = parseEventFromHtml(loadFixture("standard.html"), "https://example.com");
+    expect(parsed).not.toBeNull();
+    expect(parsed?.source).toBe("mccombs");
+    expect(parsed?.source_event_id).toBe("12001");
+    expect(parsed?.title).toBe("MSITM Lunch and Learn: Data Careers");
+    expect(parsed?.start_datetime).toBe("2026-09-15T17:00:00+00:00");
+    expect(parsed?.end_datetime).toBe("2026-09-15T18:00:00+00:00");
+    expect(parsed?.host_organization_name).toBe("MSITM");
+    expect(parsed?.location_short).toBe("GSB 2.122");
+    expect(parsed?.location_full).toBe("GSB 2.122, 2110 Speedway, Austin, TX 78705");
+    expect(parsed?.image_url).toBe(
+      "https://calendar.mccombs.utexas.edu/live/image/gid/9/lunch-and-learn-flyer.jpg",
+    );
+    expect(parsed?.rsvp_url).toBeNull();
+  });
+
+  it("handles an RSVP-required event with no image and no explicit link", () => {
+    const parsed = parseEventFromHtml(loadFixture("rsvp-required.html"), "https://example.com");
+    expect(parsed).not.toBeNull();
+    expect(parsed?.host_organization_name).toBe("Herb Kelleher Center");
+    expect(parsed?.description).toContain("RSVP required");
+    expect(parsed?.description).not.toContain("&amp;");
+    expect(parsed?.image_url).toBeNull();
+    expect(parsed?.image_aspect_ratio).toBe("none");
+    expect(parsed?.rsvp_url).toBeNull();
+  });
+
+  it("extracts a bare external registration URL from the description", () => {
+    const parsed = parseEventFromHtml(
+      loadFixture("external-registration.html"),
+      "https://example.com",
+    );
+    expect(parsed).not.toBeNull();
+    expect(parsed?.rsvp_url).toBe(
+      "https://www.eventbrite.com/e/mccombs-partner-info-session-123456789",
+    );
+    expect(parsed?.location_short).toBe("Virtual Event");
+  });
+
+  it("handles an event with no flyer image", () => {
+    const parsed = parseEventFromHtml(loadFixture("no-flyer.html"), "https://example.com");
+    expect(parsed).not.toBeNull();
+    expect(parsed?.image_url).toBeNull();
+    expect(parsed?.image_width).toBeNull();
+    expect(parsed?.image_aspect_ratio).toBe("none");
+    expect(parsed?.host_organization_name).toBe("Global Sustainability Leadership Institute");
+  });
+
+  it("returns null when no Event JSON-LD is present", () => {
+    const parsed = parseEventFromHtml("<html><body>no events here</body></html>", "https://example.com/foo");
+    expect(parsed).toBeNull();
+  });
+});
+
+describe("cleanHostOrganization", () => {
+  it("strips the McCombs boilerplate suffix", () => {
+    expect(
+      cleanHostOrganization(
+        "Alumni Engagement (McCombs School of Business - The University of Texas at Austin)",
+      ),
+    ).toBe("Alumni Engagement");
+  });
+
+  it("returns the name unchanged when there's no suffix to strip", () => {
+    expect(cleanHostOrganization("Harkey Institute")).toBe("Harkey Institute");
+  });
+
+  it("returns null for missing organizer", () => {
+    expect(cleanHostOrganization(undefined)).toBeNull();
+    expect(cleanHostOrganization(null)).toBeNull();
+  });
+});
+
+describe("extractSourceEventId", () => {
+  it("extracts the numeric id from an event URL", () => {
+    expect(
+      extractSourceEventId(
+        "https://calendar.mccombs.utexas.edu/alumni/event/11049-los-angeles-alumni-chapter",
+      ),
+    ).toBe("11049");
+  });
+
+  it("falls back to the URL path for vanity-slug events with no numeric id", () => {
+    expect(
+      extractSourceEventId("https://calendar.mccombs.utexas.edu/event/career-expo"),
+    ).toBe("event/career-expo");
+    expect(
+      extractSourceEventId(
+        "https://calendar.mccombs.utexas.edu/recruiters-corporations/event/career-expo",
+      ),
+    ).toBe("recruiters-corporations/event/career-expo");
+  });
+
+  it("returns null for an unparseable URL with no path", () => {
+    expect(extractSourceEventId("not a url")).toBeNull();
+  });
+});
+
+describe("buildLocationShort / buildLocationFull", () => {
+  it("takes the venue name before the first comma, truncated to 40 chars", () => {
+    expect(buildLocationShort("GSB 2.122, 2110 Speedway, Austin, TX 78705")).toBe("GSB 2.122");
+  });
+
+  it("falls back to the full string when there's no comma", () => {
+    expect(buildLocationShort("CBA 3.302")).toBe("CBA 3.302");
+  });
+
+  it("truncates long single-segment locations to 40 chars", () => {
+    const long = "Avalon Beverly Hills - 9400 West Olympic Blvd. Beverly Hills";
+    const short = buildLocationShort(long);
+    expect(short?.length).toBeLessThanOrEqual(40);
+    expect(short?.endsWith("...")).toBe(true);
+  });
+
+  it("returns null for missing location", () => {
+    expect(buildLocationShort(null)).toBeNull();
+    expect(buildLocationFull(undefined)).toBeNull();
+  });
+
+  it("decodes HTML entities in the full location", () => {
+    expect(buildLocationFull("AT&amp;T Hotel &amp; Conference Center")).toBe(
+      "AT&T Hotel & Conference Center",
+    );
+  });
+});
+
+describe("classifyAspectRatio", () => {
+  it("classifies horizontal, vertical, square, and none", () => {
+    expect(classifyAspectRatio(1200, 800)).toBe("horizontal");
+    expect(classifyAspectRatio(800, 1200)).toBe("vertical");
+    expect(classifyAspectRatio(1000, 1000)).toBe("square");
+    expect(classifyAspectRatio(null, null)).toBe("none");
+    expect(classifyAspectRatio(0, 0)).toBe("none");
+  });
+
+  it("uses a 5% tolerance band around square", () => {
+    expect(classifyAspectRatio(1030, 1000)).toBe("square");
+    expect(classifyAspectRatio(1060, 1000)).toBe("horizontal");
+  });
+});
+
+describe("upgradeImageUrl", () => {
+  it("strips the resize/crop path segment to get the original upload", () => {
+    expect(
+      upgradeImageUrl(
+        "https://calendar.mccombs.utexas.edu/live/image/gid/7/width/600/height/600/crop/1/src_region/0,0,2560,2560/74_KBH_Symposium.png",
+      ),
+    ).toBe("https://calendar.mccombs.utexas.edu/live/image/gid/7/74_KBH_Symposium.png");
+  });
+
+  it("is idempotent on URLs that are already original", () => {
+    const url = "https://calendar.mccombs.utexas.edu/live/image/gid/7/flyer.png";
+    expect(upgradeImageUrl(url)).toBe(url);
+  });
+
+  it("returns null for missing input", () => {
+    expect(upgradeImageUrl(null)).toBeNull();
+  });
+});
+
+describe("extractRsvpUrl", () => {
+  it("finds a bare URL in the description", () => {
+    expect(extractRsvpUrl("Register at https://example.com/register.")).toBe(
+      "https://example.com/register",
+    );
+  });
+
+  it("returns null when there's no URL", () => {
+    expect(extractRsvpUrl("RSVP required to attend.")).toBeNull();
+    expect(extractRsvpUrl(null)).toBeNull();
+  });
+});
+
+describe("decodeHtmlEntities", () => {
+  it("decodes common entities", () => {
+    expect(decodeHtmlEntities("AT&amp;T &lt;tag&gt; &quot;quote&quot; &#39;s&#39;")).toBe(
+      `AT&T <tag> "quote" 's'`,
+    );
+  });
+});
+
+describe("extractLocs", () => {
+  it("extracts <loc> entries from sitemap XML", () => {
+    const xml = `<?xml version="1.0"?>
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <url><loc>https://calendar.mccombs.utexas.edu/alumni/event/1-a</loc></url>
+        <url><loc>https://calendar.mccombs.utexas.edu/gsli/event/2-b</loc></url>
+      </urlset>`;
+    expect(extractLocs(xml)).toEqual([
+      "https://calendar.mccombs.utexas.edu/alumni/event/1-a",
+      "https://calendar.mccombs.utexas.edu/gsli/event/2-b",
+    ]);
+  });
+
+  it("returns an empty array when there are no <loc> entries", () => {
+    expect(extractLocs("<urlset></urlset>")).toEqual([]);
+  });
+});
+
+describe("parseImageDimensions", () => {
+  it("reads width/height from a PNG header", () => {
+    // Minimal valid PNG header: signature + IHDR chunk declaring 600x400.
+    const bytes = new Uint8Array(24);
+    bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    const view = new DataView(bytes.buffer);
+    view.setUint32(16, 600);
+    view.setUint32(20, 400);
+    expect(parseImageDimensions(bytes)).toEqual({ width: 600, height: 400 });
+  });
+
+  it("reads width/height from a GIF header", () => {
+    const bytes = new Uint8Array(10);
+    bytes.set([0x47, 0x49, 0x46, 0x38, 0x39, 0x61], 0); // "GIF89a"
+    const view = new DataView(bytes.buffer);
+    view.setUint16(6, 320, true);
+    view.setUint16(8, 240, true);
+    expect(parseImageDimensions(bytes)).toEqual({ width: 320, height: 240 });
+  });
+
+  it("reads width/height from a baseline JPEG SOF0 marker", () => {
+    // SOI, then a single SOF0 (0xFFC0) segment: length=17, precision=8,
+    // height=300, width=500, 1 component (minimal valid payload).
+    const bytes = new Uint8Array([
+      0xff, 0xd8, // SOI
+      0xff, 0xc0, // SOF0
+      0x00, 0x11, // segment length = 17
+      0x08, // precision
+      0x01, 0x2c, // height = 300
+      0x01, 0xf4, // width = 500
+      0x01, // number of components
+      0x01, 0x22, 0x00, // component data
+    ]);
+    expect(parseImageDimensions(bytes)).toEqual({ width: 500, height: 300 });
+  });
+
+  it("returns null for unrecognized data", () => {
+    expect(parseImageDimensions(new Uint8Array([1, 2, 3, 4]))).toBeNull();
+  });
+});

--- a/server/src/scrapers/mccombs.ts
+++ b/server/src/scrapers/mccombs.ts
@@ -1,0 +1,565 @@
+/**
+ * McCombs Events scraper — pulls events from calendar.mccombs.utexas.edu
+ * (a LiveWhale Calendar instance) and upserts them into D1.
+ *
+ * LiveWhale doesn't expose a public JSON API the way Localist does (the
+ * in-page calendar widget hydrates client-side via an undocumented AJAX
+ * endpoint that requires an obfuscated "widget syntax" token we can't
+ * reproduce server-side). Instead we use two things LiveWhale *does* render
+ * server-side and that are stable/documented:
+ *
+ *  1. `/sitemap.livewhale.xml` -> `/sitemap.events.xml` — a standard XML
+ *     sitemap listing every event page URL across all McCombs sub-calendars
+ *     (Alumni, GSLI, McCombs+, BBA, MBA programs, etc). This is our
+ *     discovery/pagination mechanism.
+ *  2. Each event page embeds a schema.org `Event` JSON-LD block
+ *     (`<script type="application/ld+json">`) for SEO. This is our data
+ *     source — title, dates, location, organizer, and (when present) a
+ *     flyer image.
+ *
+ * Caveats this approach inherits (documented rather than papered over):
+ *  - `rsvp_url` is only populated when an event's description happens to
+ *    contain a literal URL — LiveWhale doesn't expose registration links
+ *    as structured data server-side.
+ *  - `image_alt_text` is never available — not present in the JSON-LD.
+ *  - Per-event tags/audience aren't exposed server-side either, so we don't
+ *    write to `event_categories` for this source (see LOOP-147 discussion;
+ *    the `events` table also has no `tags`/`audience` column to fill).
+ *
+ * Deduplication key: (source, source_event_id) = ("mccombs", numeric event ID
+ * parsed out of the event URL, e.g. ".../event/11049-some-slug" -> "11049").
+ */
+
+import type { Env } from "../worker";
+
+const SITEMAP_INDEX_URL =
+  "https://calendar.mccombs.utexas.edu/sitemap.livewhale.xml";
+const USER_AGENT = "LonghornLoop/1.0 (+https://longhornloop.app)";
+export const SOURCE = "mccombs";
+
+// Polite scraping settings — sequential fetches with a short delay between
+// event pages, plus a hard cap so a single cron run can't run away.
+const REQUEST_DELAY_MS = 200;
+const DEFAULT_MAX_EVENTS = 500;
+
+// ─── JSON-LD shape (schema.org Event, as rendered by LiveWhale) ───────────
+
+interface LiveWhaleEventJsonLd {
+  "@type": string;
+  name: string;
+  startDate: string;
+  endDate?: string;
+  url: string;
+  description?: string;
+  location?: {
+    name?: string;
+    address?: { streetAddress?: string };
+  }[];
+  organizer?: { name?: string };
+  image?: { url?: string; width?: number; height?: number };
+}
+
+// ─── Output type ──────────────────────────────────────────────────────────
+
+export interface ParsedEvent {
+  source: string;
+  source_event_id: string;
+  title: string;
+  description: string | null;
+  start_datetime: string;
+  end_datetime: string | null;
+  location_short: string | null;
+  location_full: string | null;
+  host_organization_name: string | null;
+  event_url: string;
+  rsvp_url: string | null;
+  image_url: string | null;
+  image_width: number | null;
+  image_height: number | null;
+  image_aspect_ratio: "vertical" | "square" | "horizontal" | "none";
+  image_mime_type: string | null;
+  image_alt_text: string | null;
+}
+
+interface ScraperResult {
+  eventsProcessed: number;
+  eventsUpserted: number;
+  eventsSkipped: number;
+  errors: string[];
+  durationMs: number;
+}
+
+// ─── Pure helper functions (exported for unit tests) ──────────────────────
+
+/** Decode the small set of HTML entities LiveWhale leaves in JSON-LD text. */
+export function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&nbsp;/g, " ");
+}
+
+/** Collapse the multi-space runs left behind when LiveWhale strips HTML tags. */
+export function cleanDescription(
+  description: string | null | undefined,
+): string | null {
+  if (!description) return null;
+  const cleaned = decodeHtmlEntities(description).replace(/\s+/g, " ").trim();
+  return cleaned || null;
+}
+
+/**
+ * Find the first literal URL inside a description and treat it as the
+ * registration / RSVP link. LiveWhale renders "Register now" as plain text
+ * (the anchor's href is lost), so this only catches the case where an
+ * organizer pastes a bare URL into the description body.
+ */
+export function extractRsvpUrl(
+  description: string | null | undefined,
+): string | null {
+  if (!description) return null;
+  const match = decodeHtmlEntities(description).match(/https?:\/\/\S+/);
+  if (!match) return null;
+  return match[0].replace(/[.,)\]]+$/, "");
+}
+
+/**
+ * Strip the "Org Name (McCombs School of Business - The University of Texas
+ * at Austin)" boilerplate suffix LiveWhale appends to every organizer name,
+ * leaving the specific department/center/program (e.g. "MSITM",
+ * "Herb Kelleher Center").
+ */
+export function cleanHostOrganization(
+  organizerName: string | null | undefined,
+): string | null {
+  if (!organizerName) return null;
+  const decoded = decodeHtmlEntities(organizerName).trim();
+  const stripped = decoded.replace(/\s*\(McCombs School of Business[^)]*\)\s*$/i, "");
+  return stripped || decoded || null;
+}
+
+/**
+ * Extract a stable dedup ID from an event URL. Most events get a numeric ID
+ * LiveWhale embeds right after "/event/" (e.g. "/event/11049-some-slug" ->
+ * "11049"). Some organizers opt into a vanity slug instead
+ * (e.g. "/event/career-expo", with no number at all) — for those, fall
+ * back to the full URL path, which is still unique and stable site-wide.
+ */
+export function extractSourceEventId(eventUrl: string): string | null {
+  const numeric = eventUrl.match(/\/event\/(\d+)/);
+  if (numeric) return numeric[1];
+
+  try {
+    const path = new URL(eventUrl).pathname.replace(/^\/+|\/+$/g, "");
+    return path || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a display-friendly short location (≤ 40 chars). LiveWhale gives us
+ * one combined "venue, street address" string — we take the part before the
+ * first comma as the venue name when there is one.
+ */
+export function buildLocationShort(
+  location: string | null | undefined,
+): string | null {
+  if (!location) return null;
+  const decoded = decodeHtmlEntities(location).trim();
+  const firstSegment = decoded.split(",")[0].trim();
+  const candidate = firstSegment || decoded;
+  if (candidate.length <= 40) return candidate;
+  return candidate.substring(0, 37) + "...";
+}
+
+export function buildLocationFull(
+  location: string | null | undefined,
+): string | null {
+  if (!location) return null;
+  const decoded = decodeHtmlEntities(location).trim();
+  return decoded || null;
+}
+
+/**
+ * Classify the aspect ratio of an image. Uses a 5% tolerance band so a
+ * 1000×999 image reads as "square" not "horizontal". Returns "none" when
+ * dimensions are absent (no image).
+ */
+export function classifyAspectRatio(
+  width: number | null | undefined,
+  height: number | null | undefined,
+): "vertical" | "square" | "horizontal" | "none" {
+  if (!width || !height || width <= 0 || height <= 0) return "none";
+  const ratio = width / height;
+  if (ratio > 1.05) return "horizontal";
+  if (ratio < 0.95) return "vertical";
+  return "square";
+}
+
+/**
+ * LiveWhale serves resized/cropped variants at URLs like
+ * `/live/image/gid/{id}/width/600/height/600/crop/1/src_region/.../file.png`.
+ * Stripping the width/height/crop/src_region segment returns the original
+ * full-resolution upload at `/live/image/gid/{id}/file.png`.
+ */
+export function upgradeImageUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return url.replace(/\/width\/\d+\/height\/\d+\/crop\/\d+\/src_region\/[^/]+/, "");
+}
+
+/**
+ * Parse width/height out of raw image bytes (PNG, JPEG, or GIF headers).
+ * Returns null when the format isn't recognized or there aren't enough
+ * bytes to read the header — callers should treat that as "unknown",
+ * not an error.
+ */
+export function parseImageDimensions(
+  bytes: Uint8Array,
+): { width: number; height: number } | null {
+  // PNG: 8-byte signature, then an IHDR chunk with width/height as
+  // big-endian uint32s at offsets 16 and 20.
+  if (
+    bytes.length >= 24 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    return { width: view.getUint32(16), height: view.getUint32(20) };
+  }
+
+  // GIF: 6-byte signature, then width/height as little-endian uint16s.
+  if (
+    bytes.length >= 10 &&
+    bytes[0] === 0x47 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46
+  ) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    return { width: view.getUint16(6, true), height: view.getUint16(8, true) };
+  }
+
+  // JPEG: walk the marker segments looking for a Start-Of-Frame marker
+  // (0xC0–0xCF, excluding the DHT/JPG markers 0xC4, 0xC8, 0xCC).
+  if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    let offset = 2;
+    while (offset + 9 < bytes.length) {
+      if (bytes[offset] !== 0xff) {
+        offset++;
+        continue;
+      }
+      const marker = bytes[offset + 1];
+      if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
+        return {
+          height: view.getUint16(offset + 5),
+          width: view.getUint16(offset + 7),
+        };
+      }
+      const segmentLength = view.getUint16(offset + 2);
+      offset += 2 + segmentLength;
+    }
+  }
+
+  return null;
+}
+
+// ─── XML sitemap parsing (regex-based — sitemaps are simple, well-formed) ─
+
+export function extractLocs(xml: string): string[] {
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1].trim());
+}
+
+// ─── JSON-LD extraction + event parsing ────────────────────────────────────
+
+function extractEventJsonLd(html: string): LiveWhaleEventJsonLd | null {
+  const blocks = html.matchAll(
+    /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g,
+  );
+  for (const block of blocks) {
+    const raw = block[1]
+      .replace(/\/\*<!\[CDATA\[\*\//, "")
+      .replace(/\/\*\]\]>\*\//, "")
+      .trim();
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && parsed["@type"] === "Event") return parsed;
+    } catch {
+      // Not valid JSON (or not the block we want) — keep looking.
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse one event detail page into our normalized shape. Pure/sync so it
+ * can be unit-tested directly against saved HTML fixtures — image
+ * width/height/mime are filled in afterward by the orchestrator, which
+ * needs a network round trip the parser itself shouldn't make.
+ */
+export function parseEventFromHtml(
+  html: string,
+  pageUrl: string,
+): ParsedEvent | null {
+  const event = extractEventJsonLd(html);
+  if (!event) {
+    console.warn(`[mccombs] No Event JSON-LD found on ${pageUrl} — skipping`);
+    return null;
+  }
+
+  const eventUrl = event.url || pageUrl;
+  const sourceEventId = extractSourceEventId(eventUrl);
+  if (!sourceEventId) {
+    console.warn(`[mccombs] Could not extract event ID from ${eventUrl} — skipping`);
+    return null;
+  }
+
+  if (!event.startDate) {
+    console.warn(`[mccombs] Event ${sourceEventId} missing startDate — skipping`);
+    return null;
+  }
+
+  const place = event.location?.[0];
+  const locationString = place?.address?.streetAddress || place?.name || null;
+  const description = cleanDescription(event.description);
+  const imageUrl = upgradeImageUrl(event.image?.url);
+
+  return {
+    source: SOURCE,
+    source_event_id: sourceEventId,
+    title: decodeHtmlEntities(event.name || "").trim(),
+    description,
+    start_datetime: event.startDate,
+    end_datetime: event.endDate ?? null,
+    location_short: buildLocationShort(locationString),
+    location_full: buildLocationFull(locationString),
+    host_organization_name: cleanHostOrganization(event.organizer?.name),
+    event_url: eventUrl,
+    rsvp_url: extractRsvpUrl(description),
+    image_url: imageUrl,
+    // Filled in by fetchImageMeta() in the orchestrator when image_url is set.
+    image_width: null,
+    image_height: null,
+    image_aspect_ratio: imageUrl ? "horizontal" : "none",
+    image_mime_type: null,
+    image_alt_text: null,
+  };
+}
+
+// ─── Fetchers ───────────────────────────────────────────────────────────
+
+async function fetchText(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT, Accept: "*/*" },
+  });
+  if (!res.ok) {
+    throw new Error(`${res.status} ${res.statusText} — ${url}`);
+  }
+  return res.text();
+}
+
+/** Discover every event page URL via the LiveWhale sitemap. */
+export async function discoverEventUrls(): Promise<string[]> {
+  const indexXml = await fetchText(SITEMAP_INDEX_URL);
+  const sitemapUrls = extractLocs(indexXml);
+
+  const eventUrls = new Set<string>();
+  for (const sitemapUrl of sitemapUrls) {
+    const xml = await fetchText(sitemapUrl);
+    for (const loc of extractLocs(xml)) eventUrls.add(loc);
+  }
+  return [...eventUrls];
+}
+
+/**
+ * Fetch just enough of an image to read its header (width/height) and its
+ * Content-Type, without downloading the whole (possibly multi-MB) file.
+ */
+async function fetchImageMeta(
+  imageUrl: string,
+): Promise<{ width: number | null; height: number | null; mimeType: string | null }> {
+  try {
+    const res = await fetch(imageUrl, {
+      headers: { "User-Agent": USER_AGENT, Range: "bytes=0-65535" },
+    });
+    if (!res.ok && res.status !== 206) {
+      return { width: null, height: null, mimeType: null };
+    }
+    const mimeType = res.headers.get("content-type");
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    const dims = parseImageDimensions(bytes);
+    return { width: dims?.width ?? null, height: dims?.height ?? null, mimeType };
+  } catch (err) {
+    console.warn(`[mccombs] Failed to read image metadata for ${imageUrl}: ${err}`);
+    return { width: null, height: null, mimeType: null };
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ─── D1 upsert ────────────────────────────────────────────────────────────
+
+const UPSERT_SQL = `
+  INSERT INTO events (
+    source, source_event_id, title, description,
+    start_datetime, end_datetime,
+    location_short, location_full,
+    host_organization_id, host_organization_name,
+    event_url, rsvp_url,
+    image_url, image_width, image_height, image_aspect_ratio,
+    image_mime_type, image_alt_text,
+    expires_at,
+    visibility, status, updated_at
+  ) VALUES (
+    ?, ?, ?, ?,
+    ?, ?,
+    ?, ?,
+    NULL, ?,
+    ?, ?,
+    ?, ?, ?, ?,
+    ?, ?,
+    ?,
+    'Public', 'active', datetime('now')
+  )
+  ON CONFLICT(source, source_event_id) DO UPDATE SET
+    title                  = excluded.title,
+    description            = excluded.description,
+    start_datetime         = excluded.start_datetime,
+    end_datetime           = excluded.end_datetime,
+    location_short         = excluded.location_short,
+    location_full          = excluded.location_full,
+    host_organization_name = excluded.host_organization_name,
+    event_url              = excluded.event_url,
+    rsvp_url               = excluded.rsvp_url,
+    image_url              = excluded.image_url,
+    image_width            = excluded.image_width,
+    image_height           = excluded.image_height,
+    image_aspect_ratio     = excluded.image_aspect_ratio,
+    image_mime_type        = excluded.image_mime_type,
+    image_alt_text         = excluded.image_alt_text,
+    expires_at              = excluded.expires_at,
+    updated_at              = datetime('now')
+`;
+
+// Purge target for the cleanup job (LOOP-150): end time + 7 days, falling
+// back to the start time when an event has no end time.
+const EXPIRES_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+
+function computeExpiresAt(endDatetime: string | null, startDatetime: string): string {
+  const base = endDatetime ?? startDatetime;
+  return new Date(new Date(base).getTime() + EXPIRES_AFTER_MS).toISOString();
+}
+
+async function upsertEvent(db: D1Database, e: ParsedEvent): Promise<void> {
+  const expiresAt = computeExpiresAt(e.end_datetime, e.start_datetime);
+
+  await db
+    .prepare(UPSERT_SQL)
+    .bind(
+      e.source,
+      e.source_event_id,
+      e.title,
+      e.description,
+      e.start_datetime,
+      e.end_datetime,
+      e.location_short,
+      e.location_full,
+      e.host_organization_name,
+      e.event_url,
+      e.rsvp_url,
+      e.image_url,
+      e.image_width,
+      e.image_height,
+      e.image_aspect_ratio,
+      e.image_mime_type,
+      e.image_alt_text,
+      expiresAt,
+    )
+    .run();
+}
+
+// ─── Orchestrator ─────────────────────────────────────────────────────────
+
+export async function scrapeMccombs(
+  db: D1Database,
+  options: { maxEvents?: number; dryRun?: boolean } = {},
+): Promise<ScraperResult> {
+  const dryRun = options.dryRun ?? false;
+  const maxEvents = options.maxEvents ?? DEFAULT_MAX_EVENTS;
+  const t0 = Date.now();
+
+  const errors: string[] = [];
+  let eventsProcessed = 0;
+  let eventsUpserted = 0;
+  let eventsSkipped = 0;
+
+  let eventUrls: string[];
+  try {
+    eventUrls = await discoverEventUrls();
+  } catch (err) {
+    const msg = `Fatal error discovering event URLs: ${err}`;
+    console.error(`[mccombs] ${msg}`);
+    return { eventsProcessed: 0, eventsUpserted: 0, eventsSkipped: 0, errors: [msg], durationMs: Date.now() - t0 };
+  }
+
+  console.log(`[mccombs] Discovered ${eventUrls.length} event URLs`);
+
+  for (const url of eventUrls.slice(0, maxEvents)) {
+    eventsProcessed++;
+    try {
+      const html = await fetchText(url);
+      const parsed = parseEventFromHtml(html, url);
+      if (!parsed) {
+        eventsSkipped++;
+        continue;
+      }
+
+      if (parsed.image_url) {
+        const meta = await fetchImageMeta(parsed.image_url);
+        parsed.image_width = meta.width;
+        parsed.image_height = meta.height;
+        parsed.image_mime_type = meta.mimeType;
+        // Only override the "horizontal" default once we actually know the
+        // real dimensions — an unreadable header keeps the safe default.
+        if (meta.width && meta.height) {
+          parsed.image_aspect_ratio = classifyAspectRatio(meta.width, meta.height);
+        }
+      }
+
+      if (dryRun) {
+        console.log(
+          `[DRY RUN] Event: ${parsed.title} (${parsed.source_event_id}) — ${parsed.host_organization_name ?? "no org"}`,
+        );
+      } else {
+        await upsertEvent(db, parsed);
+        eventsUpserted++;
+      }
+    } catch (err) {
+      const msg = `Failed to process ${url}: ${err}`;
+      console.error(`[mccombs] ${msg}`);
+      errors.push(msg);
+    }
+
+    await sleep(REQUEST_DELAY_MS);
+  }
+
+  const durationMs = Date.now() - t0;
+  console.log(
+    `[mccombs] Finished in ${(durationMs / 1000).toFixed(1)}s — ${eventsUpserted} upserted, ${eventsSkipped} skipped, ${errors.length} errors`,
+  );
+
+  return { eventsProcessed, eventsUpserted, eventsSkipped, errors, durationMs };
+}
+
+/** Called by the scheduled cron handler in worker.ts. */
+export async function run(env: Env): Promise<void> {
+  console.log("[mccombs] Scraper started");
+  await scrapeMccombs(env.DB);
+}

--- a/server/src/worker.ts
+++ b/server/src/worker.ts
@@ -2,12 +2,13 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { authRoutes } from './routes/auth.worker';
-import { userRoutes } from './routes/users.worker';
 import { eventRoutes } from './routes/events.worker';
 import { notificationRoutes } from './routes/notifications.worker';
 import { savedRoutes } from './routes/saved.worker';
+import { userRoutes } from './routes/users.worker';
 // import { run as runTexasToday } from "./scrapers/texasToday"; // TODO: add texasToday scraper
-import { run as runHornsLink } from './scrapers/hornslink';
+import { run as runHornsLink } from "./scrapers/hornslink";
+import { run as runMccombs } from "./scrapers/mccombs";
 
 export type Env = {
   DB: D1Database;
@@ -121,5 +122,6 @@ export default {
     // The 6-hour scrape cron.
     // ctx.waitUntil(runTexasToday(env)); // TODO: add texasToday scraper
     ctx.waitUntil(runHornsLink(env));
+    ctx.waitUntil(runMccombs(env));
   },
 };

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -8,5 +8,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["@cloudflare/workers-types"]
-  }
+  },
+  "exclude": ["node_modules", "dist", "vitest.config.ts"]
 }

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
Fixes LOOP-147
## Summary
- Adds `server/src/scrapers/mccombs.ts`, a scraper for `calendar.mccombs.utexas.edu`
  (McCombs runs LiveWhale Calendar, not Localist like the existing UT-wide scraper).
  Discovers events via the site's XML sitemap and parses the schema.org `Event`
  JSON-LD block embedded on each event page — no new HTML-parsing dependency needed.
- Resolves flyer images to full resolution (LiveWhale serves cropped/resized
  variants by default) and reads real width/height directly from the PNG/JPEG/GIF
  header bytes via a single ranged fetch, so `image_aspect_ratio` reflects the
  actual flyer rather than a guess.
- `host_organization` maps to the specific department/center/program (e.g. "MSITM",
  "Herb Kelleher Center") pulled from the page's organizer field, not a generic
  "McCombs" fallback.
- Wires into the existing 6-hour scrape cron in `worker.ts` and adds a
  `POST /events/scrape/mccombs` dry-run route, matching the HornsLink scraper's
  pattern.
- Upserts on `(source, source_event_id)`, same as the other scrapers — safe to
  re-run without creating duplicates.
- Bootstraps `vitest` for the server package (wasn't configured before) and adds
  30 unit tests covering the four required fixture scenarios: a standard event
  with a flyer, an RSVP-required event with no link, an event with an external
  registration URL in its description, and a no-flyer event — plus the parsing
  helpers (location shortening, host-org cleanup, image upgrade/dimension
  parsing, sitemap `<loc>` extraction).

## Known gaps (flagging rather than improvising)
- `tags`/`audience` aren't captured — the `events` table has no such column,
  and McCombs' site doesn't expose category/tag data server-side (it's
  client-JS-hydrated via an internal AJAX endpoint we can't reproduce without
  a headless browser). Would need a schema migration plus further
  reverse-engineering if we want this later.
- `host_organization_slug` isn't populated — the table only has
  `host_organization_id`/`host_organization_name`, no slug column.
- `rsvp_url` is only populated when an event description happens to contain a
  literal URL; LiveWhale doesn't expose registration links as structured data.

## Test plan (all verified)
- [x] `npm test` — 30/30 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] Live dry-run via `wrangler dev` against the real calendar: 36/36 current
      events parsed successfully (0 skipped, 0 errors), including two
      vanity-slug events with no numeric ID in their URL
- [x] Verified two real flyer images resolve to full original resolution with
      correct dimensions (2560×2560 → square, 1080×1350 → vertical)
- [x] Real upsert into local D1: 36/36 rows written correctly (organizer
      names, locations, image metadata, expires_at all populated as
      expected); re-ran the scrape a second time and confirmed the row
      count stayed at 36 with no duplicates — the ON CONFLICT upsert
      updates existing rows in place