### PR TITLE
feat(explore): implement map/list toggle with event pins (LOOP-179)

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -1,23 +1,258 @@
-import { StyleSheet, Text, View } from 'react-native';
+import EventCard, { ApiEvent } from '@/app/components/EventCard';
+import EventMiniCard from '@/app/components/EventMiniCard';
+import MapViewWrapper, { LocatedEvent } from '@/app/components/MapViewWrapper';
+import { useOnboarding } from '@/app/context/OnboardingContext';
+import { api } from '@/app/lib/api';
+import { explore as exploreKeys, saved as savedKeys } from '@/app/lib/queryKeys';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'expo-router';
+import { ListIcon, MapPin } from 'phosphor-react-native';
+import React, { useState } from 'react';
+import { ActivityIndicator, FlatList, Platform, Text, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+const BURNT_ORANGE = '#BF5700';
+const TEXT_PRIMARY = '#020B12';
+const TEXT_MUTED = '#9A9A9A';
+const BG_OFFWHITE = '#F9F8F6';
+const DIVIDER = '#D2DEE0';
+const TOGGLE_BG = '#EFEFEF';
+const TOGGLE_ACTIVE_BG = '#FFFFFF';
+
+type EventsListResponse = { events: ApiEvent[] };
+type SavedListResponse = { events: ApiEvent[] };
+type ViewMode = 'list' | 'map';
+
+const IS_WEB = Platform.OS === 'web';
 
 export default function ExploreScreen() {
+  const router = useRouter();
+  const { data } = useOnboarding();
+  const token = data.token || null;
+  const queryClient = useQueryClient();
+
+  // Default to map on native (the primary feature); web is locked to list.
+  const [viewMode, setViewMode] = useState<ViewMode>(IS_WEB ? 'list' : 'map');
+  const [selectedEventId, setSelectedEventId] = useState<number | null>(null);
+
+  // GET /events is a public endpoint — no auth required, no `enabled` guard needed.
+  const eventsQuery = useQuery({
+    queryKey: exploreKeys.events({ limit: '100' }),
+    queryFn: () => api.get<EventsListResponse>('/events?limit=100', { token }),
+    staleTime: 30_000,
+  });
+
+  const savedQuery = useQuery({
+    queryKey: savedKeys.list(),
+    queryFn: () => api.get<SavedListResponse>('/saved', { token }),
+    enabled: !!token,
+  });
+
+  const savedIds = React.useMemo(
+    () => new Set((savedQuery.data?.events ?? []).map((e) => e.id)),
+    [savedQuery.data],
+  );
+
+  const toggleSave = useMutation({
+    mutationFn: async ({ eventId, wasSaved }: { eventId: number; wasSaved: boolean }) => {
+      if (wasSaved) {
+        await api.delete(`/saved/${eventId}`, { token });
+      } else {
+        await api.post(`/saved/${eventId}`, { token });
+      }
+    },
+    onMutate: async ({ eventId, wasSaved }) => {
+      await queryClient.cancelQueries({ queryKey: savedKeys.list() });
+      const previous = queryClient.getQueryData<SavedListResponse>(savedKeys.list());
+      queryClient.setQueryData<SavedListResponse>(savedKeys.list(), (old) => {
+        const list = old?.events ?? [];
+        if (wasSaved) return { events: list.filter((e) => e.id !== eventId) };
+        return { events: [...list, { id: eventId } as ApiEvent] };
+      });
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(savedKeys.list(), context.previous);
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: savedKeys.list() }),
+  });
+
+  const handleToggleSave = (eventId: number) => {
+    if (!token) return;
+    toggleSave.mutate({ eventId, wasSaved: savedIds.has(eventId) });
+  };
+
+  // Toggle: tapping the active pin dismisses the card; tapping a new pin selects it.
+  const handlePinPress = (eventId: number) => {
+    setSelectedEventId((prev) => (prev === eventId ? null : eventId));
+  };
+
+  const handleViewDetails = (eventId: number) => {
+    router.push(`/event/${eventId}`);
+  };
+
+  const allEvents = eventsQuery.data?.events ?? [];
+
+  // Type-narrowed subset: only events with non-null coordinates go on the map.
+  const locatedEvents: LocatedEvent[] = allEvents.filter(
+    (e): e is LocatedEvent => e.latitude != null && e.longitude != null,
+  );
+
+  const selectedEvent =
+    selectedEventId != null ? (allEvents.find((e) => e.id === selectedEventId) ?? null) : null;
+
+  if (eventsQuery.isPending) {
+    return (
+      <SafeAreaView
+        style={{
+          flex: 1,
+          backgroundColor: BG_OFFWHITE,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+        edges={['left', 'right']}
+      >
+        <ActivityIndicator size="large" color={BURNT_ORANGE} />
+      </SafeAreaView>
+    );
+  }
+
+  if (eventsQuery.isError) {
+    return (
+      <SafeAreaView
+        style={{
+          flex: 1,
+          backgroundColor: BG_OFFWHITE,
+          alignItems: 'center',
+          justifyContent: 'center',
+          paddingHorizontal: 24,
+        }}
+        edges={['left', 'right']}
+      >
+        <Text style={{ fontSize: 16, color: TEXT_MUTED, textAlign: 'center' }}>
+          Could not load events. Check your connection.
+        </Text>
+      </SafeAreaView>
+    );
+  }
+
+  const showList = viewMode === 'list' || IS_WEB;
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Explore Page</Text>
-      <Text>This is the placeholder explore screen.</Text>
-    </View>
+    <SafeAreaView style={{ flex: 1, backgroundColor: BG_OFFWHITE }} edges={['left', 'right']}>
+      {/* Header */}
+      <View
+        style={{
+          paddingHorizontal: 20,
+          paddingTop: 90,
+          paddingBottom: 16,
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Text style={{ fontSize: 32, fontWeight: '700', color: TEXT_PRIMARY }}>Explore</Text>
+
+        {/* Toggle hidden on web — react-native-maps has no web renderer */}
+        {!IS_WEB && (
+          <View
+            style={{
+              flexDirection: 'row',
+              backgroundColor: TOGGLE_BG,
+              borderRadius: 10,
+              padding: 3,
+            }}
+          >
+            <TouchableOpacity
+              onPress={() => {
+                setViewMode('list');
+                setSelectedEventId(null);
+              }}
+              style={{
+                padding: 7,
+                borderRadius: 8,
+                backgroundColor: viewMode === 'list' ? TOGGLE_ACTIVE_BG : 'transparent',
+              }}
+            >
+              <ListIcon
+                size={18}
+                color={viewMode === 'list' ? BURNT_ORANGE : TEXT_MUTED}
+                weight="bold"
+              />
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => setViewMode('map')}
+              style={{
+                padding: 7,
+                borderRadius: 8,
+                backgroundColor: viewMode === 'map' ? TOGGLE_ACTIVE_BG : 'transparent',
+              }}
+            >
+              <MapPin
+                size={18}
+                color={viewMode === 'map' ? BURNT_ORANGE : TEXT_MUTED}
+                weight="bold"
+              />
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+
+      {/* Divider */}
+      <View
+        style={{ height: 1, backgroundColor: DIVIDER, marginHorizontal: 20, marginBottom: 16 }}
+      />
+
+      {/* Content */}
+      {showList ? (
+        // List view — EventCard is 180px wide (hardcoded in the component) so cards
+        // render left-aligned. This is expected v1 behaviour.
+        <FlatList
+          data={allEvents}
+          keyExtractor={(item) => `${item.source}-${item.source_event_id}`}
+          contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 32, gap: 16 }}
+          showsVerticalScrollIndicator={false}
+          ListEmptyComponent={
+            <Text style={{ color: TEXT_MUTED, textAlign: 'center', marginTop: 40 }}>
+              No events found.
+            </Text>
+          }
+          renderItem={({ item }) => (
+            <EventCard
+              item={item}
+              isSaved={savedIds.has(item.id)}
+              onToggleSave={handleToggleSave}
+            />
+          )}
+        />
+      ) : (
+        // Map view — dismissal via MapView.onPress (background tap) or pin toggle.
+        // No overlay needed: MapView.onPress fires only on background taps, not marker taps.
+        <View style={{ flex: 1 }}>
+          <MapViewWrapper
+            events={locatedEvents}
+            selectedEventId={selectedEventId}
+            onPinPress={handlePinPress}
+            onMapPress={() => setSelectedEventId(null)}
+          />
+
+          {/* Mini preview card anchored to bottom, rendered above the map */}
+          {selectedEvent != null && (
+            <View
+              style={{ position: 'absolute', bottom: 0, left: 0, right: 0 }}
+              pointerEvents="box-none"
+            >
+              <EventMiniCard
+                event={selectedEvent}
+                isSaved={savedIds.has(selectedEvent.id)}
+                onToggleSave={handleToggleSave}
+                onDismiss={() => setSelectedEventId(null)}
+                onViewDetails={handleViewDetails}
+              />
+            </View>
+          )}
+        </View>
+      )}
+    </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: '600',
-    marginBottom: 8,
-  },
-});

--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -205,12 +205,13 @@ export default function ExploreScreen() {
 
       {/* Content */}
       {showList ? (
-        // List view — EventCard is 180px wide (hardcoded in the component) so cards
-        // render left-aligned. This is expected v1 behaviour.
         <FlatList
+          key="explore-grid"
           data={allEvents}
           keyExtractor={(item) => `${item.source}-${item.source_event_id}`}
-          contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 32, gap: 16 }}
+          numColumns={2}
+          columnWrapperStyle={{ gap: 12 }}
+          contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 32, gap: 12 }}
           showsVerticalScrollIndicator={false}
           ListEmptyComponent={
             <Text style={{ color: TEXT_MUTED, textAlign: 'center', marginTop: 40 }}>
@@ -222,6 +223,7 @@ export default function ExploreScreen() {
               item={item}
               isSaved={savedIds.has(item.id)}
               onToggleSave={handleToggleSave}
+              style={{ flex: 1, width: undefined, marginRight: 0 }}
             />
           )}
         />

--- a/app/components/EventCard.tsx
+++ b/app/components/EventCard.tsx
@@ -2,6 +2,7 @@ import BookmarkIcon from '@/assets/images/bookmark.svg';
 import LocationIcon from '@/assets/images/location.svg';
 import VerifiedIcon from '@/assets/images/verified.svg';
 import { useRouter } from 'expo-router';
+import { type ViewStyle } from 'react-native';
 import React from 'react';
 import { Image, Pressable, Text, TouchableOpacity, View } from 'react-native';
 
@@ -60,9 +61,10 @@ interface EventCardProps {
   item: ApiEvent;
   isSaved: boolean;
   onToggleSave: (eventId: number) => void;
+  style?: ViewStyle;
 }
 
-export default function EventCard({ item, isSaved, onToggleSave }: EventCardProps) {
+export default function EventCard({ item, isSaved, onToggleSave, style }: EventCardProps) {
   const router = useRouter();
   const hasImage = !!item.image_url;
   const hasBenefits = item.benefits && item.benefits.length > 0;
@@ -74,7 +76,7 @@ export default function EventCard({ item, isSaved, onToggleSave }: EventCardProp
   return (
     <Pressable
       onPress={handlePress}
-      style={{ width: 180 }}
+      style={[{ width: 180 }, style]}
       className="mr-4 rounded-2xl overflow-hidden bg-white border border-lhlGrey"
     >
       <View style={{ backgroundColor: '#D9D9D9', height: 160 }} className="w-full">

--- a/app/components/EventCard.tsx
+++ b/app/components/EventCard.tsx
@@ -15,6 +15,8 @@ export interface ApiEvent {
   end_datetime: string | null;
   location_short: string | null;
   location_full: string | null;
+  latitude: number | null;
+  longitude: number | null;
   host_organization_id: number;
   host_organization_name: string;
   event_url: string | null;

--- a/app/components/EventMiniCard.tsx
+++ b/app/components/EventMiniCard.tsx
@@ -1,0 +1,135 @@
+import BookmarkIcon from '@/assets/images/bookmark.svg';
+import LocationIcon from '@/assets/images/location.svg';
+import { ApiEvent, formatEventDate } from '@/app/components/EventCard';
+import React from 'react';
+import { Image, Text, TouchableOpacity, View } from 'react-native';
+
+const BURNT_ORANGE = '#BF5700';
+const TEXT_PRIMARY = '#020B12';
+const TEXT_MUTED = '#9A9A9A';
+const BORDER_GREY = '#E5E5E5';
+const BG_WHITE = '#FFFFFF';
+const BG_LIGHT = '#F1F1F1';
+const BG_SAVED = '#FFF3EC';
+
+interface EventMiniCardProps {
+  event: ApiEvent;
+  isSaved: boolean;
+  onToggleSave: (eventId: number) => void;
+  onDismiss: () => void;
+  onViewDetails: (eventId: number) => void;
+}
+
+export default function EventMiniCard({
+  event,
+  isSaved,
+  onToggleSave,
+  onDismiss,
+  onViewDetails,
+}: EventMiniCardProps) {
+  return (
+    <View
+      style={{
+        margin: 16,
+        backgroundColor: BG_WHITE,
+        borderRadius: 16,
+        padding: 12,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        shadowColor: '#000',
+        shadowOpacity: 0.12,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 4 },
+        elevation: 6,
+        borderWidth: 1,
+        borderColor: BORDER_GREY,
+      }}
+    >
+      {/* Thumbnail */}
+      <View
+        style={{
+          width: 72,
+          height: 72,
+          borderRadius: 10,
+          backgroundColor: '#D9D9D9',
+          overflow: 'hidden',
+          flexShrink: 0,
+        }}
+      >
+        {event.image_url != null && (
+          <Image
+            source={{ uri: event.image_url }}
+            style={{ width: '100%', height: '100%' }}
+            resizeMode="cover"
+          />
+        )}
+      </View>
+
+      {/* Info */}
+      <View style={{ flex: 1 }}>
+        <Text
+          style={{ fontSize: 14, fontWeight: '700', color: TEXT_PRIMARY, marginBottom: 2 }}
+          numberOfLines={1}
+        >
+          {event.title}
+        </Text>
+        <Text style={{ fontSize: 12, color: TEXT_MUTED, marginBottom: 2 }} numberOfLines={1}>
+          {event.host_organization_name}
+        </Text>
+        <Text style={{ fontSize: 12, color: TEXT_MUTED, marginBottom: 4 }}>
+          {formatEventDate(event.start_datetime)}
+        </Text>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+          <LocationIcon width={12} height={12} />
+          <Text style={{ fontSize: 11, color: TEXT_MUTED }} numberOfLines={1}>
+            {event.location_short ?? 'TBD'}
+          </Text>
+        </View>
+      </View>
+
+      {/* Actions column */}
+      <View style={{ alignItems: 'center', gap: 8, flexShrink: 0 }}>
+        <TouchableOpacity
+          onPress={onDismiss}
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 14,
+            backgroundColor: BG_LIGHT,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text style={{ fontSize: 13, color: TEXT_MUTED }}>✕</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => onToggleSave(event.id)}
+          style={{
+            width: 28,
+            height: 28,
+            borderRadius: 14,
+            backgroundColor: isSaved ? BG_SAVED : BG_LIGHT,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <BookmarkIcon width={10} height={13} color={isSaved ? BURNT_ORANGE : TEXT_PRIMARY} />
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => onViewDetails(event.id)}
+          style={{
+            paddingHorizontal: 10,
+            paddingVertical: 5,
+            backgroundColor: BURNT_ORANGE,
+            borderRadius: 8,
+          }}
+        >
+          <Text style={{ fontSize: 11, fontWeight: '600', color: '#FFFFFF' }}>View</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/app/components/MapViewWrapper.tsx
+++ b/app/components/MapViewWrapper.tsx
@@ -1,0 +1,78 @@
+import { ApiEvent } from '@/app/components/EventCard';
+import React, { useRef } from 'react';
+import { Platform, Text, View } from 'react-native';
+import MapView, { Marker } from 'react-native-maps';
+
+const BURNT_ORANGE = '#BF5700';
+const SELECTED_ORANGE = '#FF8C00';
+
+const UT_REGION = {
+  latitude: 30.2849,
+  longitude: -97.7341,
+  latitudeDelta: 0.02,
+  longitudeDelta: 0.02,
+} as const;
+
+export type LocatedEvent = ApiEvent & { latitude: number; longitude: number };
+
+interface MapViewWrapperProps {
+  events: LocatedEvent[];
+  selectedEventId: number | null;
+  onPinPress: (eventId: number) => void;
+  onMapPress: () => void;
+}
+
+export default function MapViewWrapper({
+  events,
+  selectedEventId,
+  onPinPress,
+  onMapPress,
+}: MapViewWrapperProps) {
+  if (Platform.OS === 'web') {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Text
+          style={{
+            fontSize: 16,
+            color: '#9A9A9A',
+            textAlign: 'center',
+            paddingHorizontal: 40,
+            lineHeight: 24,
+          }}
+        >
+          Map view is available in the mobile app.
+        </Text>
+      </View>
+    );
+  }
+
+  const pinJustPressed = useRef(false);
+
+  return (
+    <View style={{ flex: 1 }}>
+      <MapView
+        style={{ flex: 1 }}
+        initialRegion={UT_REGION}
+        onPress={() => {
+          if (pinJustPressed.current) {
+            pinJustPressed.current = false;
+            return;
+          }
+          onMapPress();
+        }}
+      >
+        {events.map((event) => (
+          <Marker
+            key={event.id}
+            coordinate={{ latitude: event.latitude, longitude: event.longitude }}
+            pinColor={selectedEventId === event.id ? SELECTED_ORANGE : BURNT_ORANGE}
+            onPress={() => {
+              pinJustPressed.current = true;
+              onPinPress(event.id);
+            }}
+          />
+        ))}
+      </MapView>
+    </View>
+  );
+}

--- a/app/components/MapViewWrapper.web.tsx
+++ b/app/components/MapViewWrapper.web.tsx
@@ -1,0 +1,30 @@
+import { ApiEvent } from '@/app/components/EventCard';
+import React from 'react';
+import { Text, View } from 'react-native';
+
+export type LocatedEvent = ApiEvent & { latitude: number; longitude: number };
+
+interface MapViewWrapperProps {
+  events: LocatedEvent[];
+  selectedEventId: number | null;
+  onPinPress: (eventId: number) => void;
+  onMapPress: () => void;
+}
+
+export default function MapViewWrapper(_props: MapViewWrapperProps) {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text
+        style={{
+          fontSize: 16,
+          color: '#9A9A9A',
+          textAlign: 'center',
+          paddingHorizontal: 40,
+          lineHeight: 24,
+        }}
+      >
+        Map view is available in the mobile app.
+      </Text>
+    </View>
+  );
+}

--- a/app/lib/queryKeys.ts
+++ b/app/lib/queryKeys.ts
@@ -21,3 +21,9 @@ export const notifications = {
   all: ['notifications'] as const,
   list: () => [...notifications.all, 'list'] as const,
 };
+
+export const explore = {
+  all: ['explore'] as const,
+  events: (params: Record<string, string | undefined> = {}) =>
+    [...explore.all, 'events', params] as const,
+};

--- a/metro.config.js
+++ b/metro.config.js
@@ -14,4 +14,17 @@ config.resolver = {
   sourceExts: [...config.resolver.sourceExts, 'svg'],
 };
 
+// react-native-maps uses native-only APIs unavailable in web bundler.
+// Stub it to an empty module on web; MapViewWrapper.tsx guards with Platform.OS.
+const defaultResolveRequest = config.resolver.resolveRequest;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (platform === 'web' && moduleName === 'react-native-maps') {
+    return { type: 'empty' };
+  }
+  if (defaultResolveRequest) {
+    return defaultResolveRequest(context, moduleName, platform);
+  }
+  return context.resolveRequest(context, moduleName, platform);
+};
+
 module.exports = withNativeWind(config, { input: './app/globals.css' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",
+        "react-native-maps": "1.20.1",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
@@ -3515,6 +3516,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
@@ -11579,6 +11586,28 @@
       },
       "peerDependencies": {
         "react-native": ">=0.48.4"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.20.1.tgz",
+      "integrity": "sha512-NZI3B5Z6kxAb8gzb2Wxzu/+P2SlFIg1waHGIpQmazDSCRkNoHNY4g96g+xS0QPSaG/9xRBbDNnd2f2/OW6t6LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">= 17.0.1",
+        "react-native": ">= 0.64.3",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
+    "react-native-maps": "1.20.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",


### PR DESCRIPTION
Implements the Explore tab with a map/list view toggle for event discovery.

Changes:
- Explore screen (explore.tsx): replaces stub with full implementation — list view (FlatList of EventCards) and map view with toggle
- MapViewWrapper (native): renders react-native-maps MapView centered on UT Austin, burnt orange pins, selected pin highlighted, mini card on tap
- MapViewWrapper.web: platform stub — list-only on web since react-native-maps has no web renderer; toggle hidden on web
- EventMiniCard: bottom-anchored preview card on pin tap — thumbnail, title, org, date, location, dismiss/save/view actions
- EventCard (ApiEvent): adds latitude and longitude fields
- queryKeys: adds explore namespace
- metro.config.js: stubs react-native-maps to empty module on web to prevent native-only bundler crash

Screenshots:
<img width="424" height="806" alt="Screenshot 2026-06-30 at 17 06 08" src="https://github.com/user-attachments/assets/c41a1913-40f7-4eec-8f86-6a59047db933" />
