### PR TITLE
feat: layered poster look on card list and detail screen

### DIFF
--- a/app/(auth)/FrontPage.tsx
+++ b/app/(auth)/FrontPage.tsx
@@ -81,9 +81,7 @@ export default function FrontPage() {
               router.replace('/(tabs)/home');
             }}
           >
-            <Text className="text-xs text-gray-400 underline">
-              [DEV] Skip to Home
-            </Text>
+            <Text className="text-xs text-gray-400 underline">[DEV] Skip to Home</Text>
           </Pressable>
         )}
       </ScrollView>

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -42,25 +42,270 @@ const TAG_TO_CATEGORY: Record<string, string> = {};
 
 // The interest categories and their tags (mirrored from InterestSelection).
 const INTEREST_CATEGORIES: { id: string; label: string; tags: string[] }[] = [
-  { id: 'music', label: 'Music', tags: ['Rock & Alternative', 'Hip Hop & Rap', 'Electronic & EDM', 'Country & Folk', 'Jazz & Blues', 'Classical & Opera', 'Pop & Top 40', 'R&B & Soul', 'Indie & Underground', 'Latin & Reggaeton', 'K-Pop & J-Pop'] },
-  { id: 'arts', label: 'Arts & Culture', tags: ['Art Exhibitions & Galleries', 'Theater & Broadway', 'Dance Performances', 'Film & Cinema', 'Photography', 'Sculpture & Installation Art', 'Poetry & Spoken Word', 'Street Art & Graffiti', 'Cultural Festivals', 'Museum Tours', 'Anime'] },
-  { id: 'sports', label: 'Sports & Fitness', tags: ['Football & Soccer', 'Basketball', 'Baseball & Softball', 'Tennis & Racquet Sports', 'Running & Marathon', 'Yoga & Meditation', 'Cycling & Biking', 'Swimming & Water Sports', 'Martial Arts & Boxing', 'Extreme Sports', 'Golf', 'CrossFit & HIIT'] },
-  { id: 'food', label: 'Food & Drink', tags: ['Wine Tasting', 'Craft Beer & Breweries', 'Cocktails & Mixology', 'Fine Dining', 'Street Food & Food Trucks', 'Vegan & Vegetarian', 'Coffee & Tea', 'Baking & Pastries', 'International Cuisine', 'Cooking Classes', 'Food Festivals'] },
-  { id: 'tech', label: 'Technology', tags: ['Startup & Entrepreneurship', 'AI & Machine Learning', 'Blockchain & Crypto', 'Web Development', 'Mobile Apps', 'Cybersecurity', 'Gaming & Esports', 'VR & AR', 'Robotics', 'Tech Conferences', 'Hackathons'] },
-  { id: 'health', label: 'Health & Wellness', tags: ['Mindfulness & Meditation', 'Nutrition & Diet', 'Mental Health Awareness', 'Fitness Challenges', 'Spa & Self-Care', 'Alternative Medicine', 'Health Fairs'] },
-  { id: 'business', label: 'Business', tags: ['Networking Events', 'Career Fairs', 'Workshops & Seminars', 'Leadership Summits', 'Investment & Finance', 'Marketing & Branding', 'Real Estate'] },
-  { id: 'outdoors', label: 'Outdoors', tags: ['Hiking & Trails', 'Camping', 'Fishing', 'Kayaking & Canoeing', 'Rock Climbing', 'Gardening & Botany', 'Bird Watching', 'Nature Photography'] },
-  { id: 'learning', label: 'Learning & Education', tags: ['Book Clubs', 'Language Learning', 'STEM Workshops', 'History Lectures', 'Creative Writing', 'Study Groups', 'Academic Competitions'] },
-  { id: 'nightlife', label: 'Nightlife', tags: ['Club Events', 'Live DJ Sets', 'Bar Crawls', 'Karaoke Nights', 'Comedy Shows', 'Late-Night Events', 'Theme Parties'] },
-  { id: 'spirituality', label: 'Spirituality', tags: ['Meditation Retreats', 'Religious Services', 'Interfaith Dialogues', 'Prayer Groups', 'Spiritual Workshops', 'Community Service'] },
-  { id: 'performing', label: 'Performing Arts', tags: ['Stand-up Comedy', 'Improv Shows', 'Musical Theater', 'Orchestra & Symphony', 'Circus & Acrobatics', 'Spoken Word & Poetry Slams', 'Drag Shows'] },
-  { id: 'science', label: 'Science', tags: ['Astronomy & Stargazing', 'Biology & Ecology', 'Chemistry Demos', 'Physics Talks', 'Environmental Science', 'Space Exploration', 'Citizen Science'] },
-  { id: 'shopping', label: 'Shopping & Fashion', tags: ['Thrift & Vintage', 'Pop-Up Markets', 'Fashion Shows', 'Streetwear', 'Sustainable Fashion', 'DIY & Crafts', 'Flea Markets'] },
-  { id: 'travel', label: 'Travel', tags: ['Study Abroad Info', 'Travel Meetups', 'Cultural Exchange', 'Road Trip Planning', 'Budget Travel Tips', 'Adventure Travel'] },
-  { id: 'gaming', label: 'Gaming', tags: ['Video Game Tournaments', 'Board Game Nights', 'Tabletop RPGs', 'LAN Parties', 'Game Dev Meetups', 'Retro Gaming', 'Card Games'] },
-  { id: 'home', label: 'Home & Lifestyle', tags: ['Interior Design', 'Home Organization', 'Sustainable Living', 'Budgeting & Finance', 'Meal Prep', 'DIY Home Projects'] },
-  { id: 'networking', label: 'Networking', tags: ['Professional Mixers', 'Alumni Events', 'Mentorship Programs', 'Industry Panels', 'Speed Networking', 'Co-working Sessions'] },
-  { id: 'pets', label: 'Pets & Animals', tags: ['Dog-Friendly Events', 'Pet Adoption', 'Animal Rescue', 'Wildlife Conservation', 'Equestrian', 'Pet Training'] },
+  {
+    id: 'music',
+    label: 'Music',
+    tags: [
+      'Rock & Alternative',
+      'Hip Hop & Rap',
+      'Electronic & EDM',
+      'Country & Folk',
+      'Jazz & Blues',
+      'Classical & Opera',
+      'Pop & Top 40',
+      'R&B & Soul',
+      'Indie & Underground',
+      'Latin & Reggaeton',
+      'K-Pop & J-Pop',
+    ],
+  },
+  {
+    id: 'arts',
+    label: 'Arts & Culture',
+    tags: [
+      'Art Exhibitions & Galleries',
+      'Theater & Broadway',
+      'Dance Performances',
+      'Film & Cinema',
+      'Photography',
+      'Sculpture & Installation Art',
+      'Poetry & Spoken Word',
+      'Street Art & Graffiti',
+      'Cultural Festivals',
+      'Museum Tours',
+      'Anime',
+    ],
+  },
+  {
+    id: 'sports',
+    label: 'Sports & Fitness',
+    tags: [
+      'Football & Soccer',
+      'Basketball',
+      'Baseball & Softball',
+      'Tennis & Racquet Sports',
+      'Running & Marathon',
+      'Yoga & Meditation',
+      'Cycling & Biking',
+      'Swimming & Water Sports',
+      'Martial Arts & Boxing',
+      'Extreme Sports',
+      'Golf',
+      'CrossFit & HIIT',
+    ],
+  },
+  {
+    id: 'food',
+    label: 'Food & Drink',
+    tags: [
+      'Wine Tasting',
+      'Craft Beer & Breweries',
+      'Cocktails & Mixology',
+      'Fine Dining',
+      'Street Food & Food Trucks',
+      'Vegan & Vegetarian',
+      'Coffee & Tea',
+      'Baking & Pastries',
+      'International Cuisine',
+      'Cooking Classes',
+      'Food Festivals',
+    ],
+  },
+  {
+    id: 'tech',
+    label: 'Technology',
+    tags: [
+      'Startup & Entrepreneurship',
+      'AI & Machine Learning',
+      'Blockchain & Crypto',
+      'Web Development',
+      'Mobile Apps',
+      'Cybersecurity',
+      'Gaming & Esports',
+      'VR & AR',
+      'Robotics',
+      'Tech Conferences',
+      'Hackathons',
+    ],
+  },
+  {
+    id: 'health',
+    label: 'Health & Wellness',
+    tags: [
+      'Mindfulness & Meditation',
+      'Nutrition & Diet',
+      'Mental Health Awareness',
+      'Fitness Challenges',
+      'Spa & Self-Care',
+      'Alternative Medicine',
+      'Health Fairs',
+    ],
+  },
+  {
+    id: 'business',
+    label: 'Business',
+    tags: [
+      'Networking Events',
+      'Career Fairs',
+      'Workshops & Seminars',
+      'Leadership Summits',
+      'Investment & Finance',
+      'Marketing & Branding',
+      'Real Estate',
+    ],
+  },
+  {
+    id: 'outdoors',
+    label: 'Outdoors',
+    tags: [
+      'Hiking & Trails',
+      'Camping',
+      'Fishing',
+      'Kayaking & Canoeing',
+      'Rock Climbing',
+      'Gardening & Botany',
+      'Bird Watching',
+      'Nature Photography',
+    ],
+  },
+  {
+    id: 'learning',
+    label: 'Learning & Education',
+    tags: [
+      'Book Clubs',
+      'Language Learning',
+      'STEM Workshops',
+      'History Lectures',
+      'Creative Writing',
+      'Study Groups',
+      'Academic Competitions',
+    ],
+  },
+  {
+    id: 'nightlife',
+    label: 'Nightlife',
+    tags: [
+      'Club Events',
+      'Live DJ Sets',
+      'Bar Crawls',
+      'Karaoke Nights',
+      'Comedy Shows',
+      'Late-Night Events',
+      'Theme Parties',
+    ],
+  },
+  {
+    id: 'spirituality',
+    label: 'Spirituality',
+    tags: [
+      'Meditation Retreats',
+      'Religious Services',
+      'Interfaith Dialogues',
+      'Prayer Groups',
+      'Spiritual Workshops',
+      'Community Service',
+    ],
+  },
+  {
+    id: 'performing',
+    label: 'Performing Arts',
+    tags: [
+      'Stand-up Comedy',
+      'Improv Shows',
+      'Musical Theater',
+      'Orchestra & Symphony',
+      'Circus & Acrobatics',
+      'Spoken Word & Poetry Slams',
+      'Drag Shows',
+    ],
+  },
+  {
+    id: 'science',
+    label: 'Science',
+    tags: [
+      'Astronomy & Stargazing',
+      'Biology & Ecology',
+      'Chemistry Demos',
+      'Physics Talks',
+      'Environmental Science',
+      'Space Exploration',
+      'Citizen Science',
+    ],
+  },
+  {
+    id: 'shopping',
+    label: 'Shopping & Fashion',
+    tags: [
+      'Thrift & Vintage',
+      'Pop-Up Markets',
+      'Fashion Shows',
+      'Streetwear',
+      'Sustainable Fashion',
+      'DIY & Crafts',
+      'Flea Markets',
+    ],
+  },
+  {
+    id: 'travel',
+    label: 'Travel',
+    tags: [
+      'Study Abroad Info',
+      'Travel Meetups',
+      'Cultural Exchange',
+      'Road Trip Planning',
+      'Budget Travel Tips',
+      'Adventure Travel',
+    ],
+  },
+  {
+    id: 'gaming',
+    label: 'Gaming',
+    tags: [
+      'Video Game Tournaments',
+      'Board Game Nights',
+      'Tabletop RPGs',
+      'LAN Parties',
+      'Game Dev Meetups',
+      'Retro Gaming',
+      'Card Games',
+    ],
+  },
+  {
+    id: 'home',
+    label: 'Home & Lifestyle',
+    tags: [
+      'Interior Design',
+      'Home Organization',
+      'Sustainable Living',
+      'Budgeting & Finance',
+      'Meal Prep',
+      'DIY Home Projects',
+    ],
+  },
+  {
+    id: 'networking',
+    label: 'Networking',
+    tags: [
+      'Professional Mixers',
+      'Alumni Events',
+      'Mentorship Programs',
+      'Industry Panels',
+      'Speed Networking',
+      'Co-working Sessions',
+    ],
+  },
+  {
+    id: 'pets',
+    label: 'Pets & Animals',
+    tags: [
+      'Dog-Friendly Events',
+      'Pet Adoption',
+      'Animal Rescue',
+      'Wildlife Conservation',
+      'Equestrian',
+      'Pet Training',
+    ],
+  },
 ];
 
 // Build TAG_TO_CATEGORY lookup at module load.
@@ -97,9 +342,7 @@ const CATEGORY_TO_QUERY: Record<string, string> = {
 // Derive carousel definitions from user's selected tags.
 function buildCarousels(userTags: string[]): CarouselDef[] {
   // Always start with Upcoming.
-  const carousels: CarouselDef[] = [
-    { key: 'upcoming', title: 'Upcoming', search: 'limit=10' },
-  ];
+  const carousels: CarouselDef[] = [{ key: 'upcoming', title: 'Upcoming', search: 'limit=10' }];
 
   // Derive unique categories from user tags, in order of first appearance.
   const seen = new Set<string>();
@@ -242,7 +485,12 @@ export default function HomeScreen() {
   );
 
   // Toggle save with optimistic UI.
-  const toggleSave = useMutation<void, unknown, { eventId: number; wasSaved: boolean }, { previous?: SavedListResponse }>({
+  const toggleSave = useMutation<
+    void,
+    unknown,
+    { eventId: number; wasSaved: boolean },
+    { previous?: SavedListResponse }
+  >({
     mutationFn: async ({ eventId, wasSaved }) => {
       if (wasSaved) {
         await api.delete(`/saved/${eventId}`, { token });
@@ -298,9 +546,7 @@ export default function HomeScreen() {
               {getGreeting()}
             </Text>
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 4 }}>
-              <Text style={{ fontSize: 32, fontWeight: '700', color: '#020B12' }}>
-                {firstName}
-              </Text>
+              <Text style={{ fontSize: 32, fontWeight: '700', color: '#020B12' }}>{firstName}</Text>
               <HookemIcon width={31} height={31} />
             </View>
           </View>

--- a/app/components/EventCard.tsx
+++ b/app/components/EventCard.tsx
@@ -75,13 +75,38 @@ export default function EventCard({ item, isSaved, onToggleSave }: EventCardProp
       style={{ width: 180 }}
       className="mr-4 rounded-2xl overflow-hidden bg-white border border-lhlGrey"
     >
-      <View style={{ backgroundColor: '#D9D9D9', height: 160 }} className="w-full">
+      <View
+        style={{
+          height: 160,
+          width: '100%',
+          backgroundColor: '#D9D9D9',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
         {hasImage && (
-          <Image
-            source={{ uri: item.image_url! }}
-            style={{ width: '100%', height: '100%' }}
-            resizeMode="cover"
-          />
+          <>
+            {/* Blurred copy of the poster fills the card, giving the
+                foreground image an atmospheric backdrop. */}
+            <Image
+              source={{ uri: item.image_url! }}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                opacity: 0.55,
+              }}
+              blurRadius={18}
+              resizeMode="cover"
+            />
+            <Image
+              source={{ uri: item.image_url! }}
+              style={{ width: '100%', height: '100%' }}
+              resizeMode="contain"
+            />
+          </>
         )}
 
         {hasBenefits && (
@@ -104,7 +129,7 @@ export default function EventCard({ item, isSaved, onToggleSave }: EventCardProp
 
         <TouchableOpacity
           onPress={(e) => {
-            // Don't let the bookmark tap bubble up and trigger card navigation.
+            // Stop the tap so it doesn't also open the event.
             e.stopPropagation();
             onToggleSave(item.id);
           }}

--- a/app/event/[id]/index.tsx
+++ b/app/event/[id]/index.tsx
@@ -17,6 +17,7 @@ import { api, ApiError } from '@/app/lib/api';
 import { events as eventsKeys, saved as savedKeys } from '@/app/lib/queryKeys';
 import { addRsvp, isRsvped as isRsvpedInStore, removeRsvp } from '@/app/lib/rsvpStore';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { LinearGradient } from 'expo-linear-gradient';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
 import React, { useEffect, useState } from 'react';
@@ -25,6 +26,7 @@ import {
   Image,
   Pressable,
   ScrollView,
+  StyleSheet,
   Text,
   TouchableOpacity,
   View,
@@ -40,6 +42,21 @@ const TEXT_MUTED = '#7A7A7A';
 const BORDER_GREY = '#E5E5E5';
 const CHIP_BG = '#F1F1F1';
 const REPORT_RED = '#E11D48';
+
+// Container aspect ratio for the poster. Defaults to portrait since most
+// flyers are vertical.
+function posterAspectRatio(kind: string | null): number {
+  switch (kind) {
+    case 'horizontal':
+      return 1.4;
+    case 'square':
+      return 1;
+    case 'vertical':
+    case 'none':
+    default:
+      return 0.72;
+  }
+}
 
 function formatShortDate(isoString: string): string {
   const date = new Date(isoString);
@@ -340,39 +357,60 @@ export default function EventDetailScreen() {
         showsVerticalScrollIndicator={false}
         contentContainerStyle={{ paddingBottom: 120 }}
       >
+        {/* Soft two-layer gradient behind the poster. */}
         <SafeAreaView edges={['top']} style={{ backgroundColor: BG_OFFWHITE }}>
-          <View
-            style={{
-              backgroundColor: BG_OFFWHITE,
-              paddingTop: 8,
-              paddingBottom: 24,
-              paddingHorizontal: 24,
-              alignItems: 'center',
-            }}
-          >
-            <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
-              <ArrowLeftIcon width={20} height={20} />
-            </TouchableOpacity>
+          <View style={{ position: 'relative' }}>
+            <LinearGradient
+              colors={['rgba(146,141,135,1)', 'rgba(248,239,229,1)']}
+              start={{ x: 0.5, y: 0 }}
+              end={{ x: 0.5, y: 1 }}
+              style={StyleSheet.absoluteFill}
+            />
+            <LinearGradient
+              colors={['rgba(249,248,245,1)', 'rgba(146,141,135,0.15)', 'rgba(249,248,245,1)']}
+              locations={[0, 0.5144, 1]}
+              start={{ x: 0.5, y: 0 }}
+              end={{ x: 0.5, y: 1 }}
+              style={StyleSheet.absoluteFill}
+            />
 
-            <View style={styles.poster}>
-              {event.image_url ? (
-                <Image
-                  source={{ uri: event.image_url }}
-                  style={{ width: '100%', height: '100%' }}
-                  resizeMode="cover"
-                />
-              ) : (
-                <View
-                  style={{
-                    flex: 1,
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    backgroundColor: '#D9D9D9',
-                  }}
-                >
-                  <Text style={{ color: TEXT_MUTED, fontSize: 14 }}>No image</Text>
-                </View>
-              )}
+            <View
+              style={{
+                paddingTop: 8,
+                paddingBottom: 24,
+                paddingHorizontal: 24,
+                alignItems: 'center',
+              }}
+            >
+              <TouchableOpacity onPress={() => router.back()} style={styles.backButton}>
+                <ArrowLeftIcon width={20} height={20} />
+              </TouchableOpacity>
+
+              <View
+                style={[
+                  styles.poster,
+                  { aspectRatio: posterAspectRatio(event.image_aspect_ratio) },
+                ]}
+              >
+                {event.image_url ? (
+                  <Image
+                    source={{ uri: event.image_url }}
+                    style={{ width: '100%', height: '100%' }}
+                    resizeMode="contain"
+                  />
+                ) : (
+                  <View
+                    style={{
+                      flex: 1,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: '#D9D9D9',
+                    }}
+                  >
+                    <Text style={{ color: TEXT_MUTED, fontSize: 14 }}>No image</Text>
+                  </View>
+                )}
+              </View>
             </View>
           </View>
         </SafeAreaView>
@@ -536,11 +574,10 @@ const styles = {
     zIndex: 10,
   },
   poster: {
-    width: '60%' as const,
-    aspectRatio: 0.72,
+    // Aspect ratio comes from posterAspectRatio() at render time.
+    width: '70%' as const,
     borderRadius: 12,
     overflow: 'hidden' as const,
-    backgroundColor: '#fff',
     shadowColor: '#000',
     shadowOpacity: 0.12,
     shadowRadius: 12,

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -41,7 +41,6 @@ interface Section {
   data: Notification[];
 }
 
-
 // ---------- Helpers ----------
 
 function groupByDate(items: Notification[]): Section[] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
         "expo-splash-screen": "~31.0.13",
@@ -6785,6 +6786,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-15.0.8.tgz",
+      "integrity": "sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-splash-screen": "~31.0.13",


### PR DESCRIPTION
## What
- Cards show the poster with a blurred copy of itself as backdrop, so the surrounding card area picks up the poster's colors instead of a plain grey box.
- Detail screen shows the whole poster (contain, not cover) on the two-layer warm gradient from Figma, so portrait flyers aren't cropped.

## Files
- app/components/EventCard.tsx: two stacked Images (blurred cover + contained foreground) in the card image area.
- app/event/[id]/index.tsx: LinearGradient behind the poster, posterAspectRatio helper, resizeMode="contain" on the hero image, dropped the white background on styles.poster.
- expo-linear-gradient added.

## Test
Reload the app. Home cards show flyers on their own tinted backdrop. Detail view shows the full flyer with a soft gradient surround.

<img width="676" height="480" alt="image" src="https://github.com/user-attachments/assets/0c3a15b4-5501-425c-912e-a8b0717e3a62" />

<img width="674" height="612" alt="image" src="https://github.com/user-attachments/assets/246b08e4-6ed4-4ccc-ae8f-37a88d9c72b7" />

** needed for database convention

Note: Re-addded home.tsx for CI clean