### PR TITLE
refactor(server): extract shared events pipeline

### DIFF
--- a/docs/org-profiles.md
+++ b/docs/org-profiles.md
@@ -1,0 +1,79 @@
+# Organization profiles — model and roadmap
+
+## Today
+
+Events carry two org-related columns:
+
+- `host_organization_id` (nullable FK to `organizations.id`)
+- `host_organization_name` (plain text, always populated)
+
+The `organizations` table is keyed by the source's stable numeric id. It
+holds the org's display name, profile picture, and (eventually) claim /
+verification state.
+
+Whether we write an `organizations` row depends on the source:
+
+| Source      | `sourceOrgId` | Behavior                                                            |
+| ----------- | ------------- | ------------------------------------------------------------------- |
+| HornsLink   | number        | Upsert into `organizations`, link event via `host_organization_id`. |
+| Texas Today | null          | Skip `organizations`. Event stores name only.                       |
+| McCombs     | null          | Skip `organizations`. Event stores name only.                       |
+
+`NormalizedOrganization.sourceOrgId` in `server/src/events/types.ts`
+encodes this: HornsLink hands us the number, the others hand us null.
+`ingest.ts` checks the field and skips the org upsert when null.
+
+## Why HornsLink events get org rows and department events don't
+
+HornsLink orgs are independent, brand-y entities (SGA, MSA, IEEE,
+Longhorn Robotics, etc.). Each one competes for members, wants their
+own presence, and can plausibly claim + verify their page.
+
+Texas Today and McCombs events come from academic units — the McCombs
+School of Business, the BBA program, the GSLI office. Those are
+institutional and don't "sign up" for Loop the way a student org does.
+There's no obvious owner to claim the page, and forcing them into the
+`organizations` table would create weird questions ("is McCombs+ the
+same org as McCombs BBA?"). Keeping the department name as a plain
+text field on the event avoids that.
+
+## Claim + verification flow (roadmap)
+
+Not built yet. When we build it, the outline is:
+
+1. Org page reachable at `/org/[sourceOrgId]` (HornsLink orgs only for
+   v1). Shows profile picture, name, and their events.
+2. "Is this your org?" CTA opens a claim flow. Applicant supplies an
+   email at the org's domain or a verification code we hand out
+   manually to anchor orgs.
+3. On approval, `organizations.verified` flips to 1. Loop displays
+   the verified badge next to the org name on event cards and detail
+   screens.
+4. Verified orgs get admin controls: edit profile picture, hide events,
+   add a description.
+
+## Department profiles (future)
+
+If we later decide departments deserve claimable pages (e.g. an
+official McCombs presence with pinned events), the pipeline supports
+it two ways:
+
+1. Add a lookup table `department_orgs (source, name, org_id)` that
+   maps a department name to a manually-created `organizations.id`.
+   The scraper checks this table before deciding whether to leave
+   `sourceOrgId` null.
+2. Change the ingest layer to auto-create org rows keyed by
+   `(source, name)` for null-id sources. Cheaper but risks duplicate
+   rows when the same department appears under slightly different
+   names.
+
+Option 1 is preferable — deliberate, low volume, no dedupe hell.
+
+## Source-of-truth summary
+
+- Display name on a card → `events.host_organization_name` (always
+  present, snapshot from scrape time).
+- Verified badge / org page link → only when
+  `events.host_organization_id` is non-null.
+- Anything a user "claims" or "follows" → the `organizations` row,
+  keyed by the source's numeric id.

--- a/server/src/events/ingest.ts
+++ b/server/src/events/ingest.ts
@@ -1,0 +1,195 @@
+// Writes NormalizedEvent[] into D1. Only place that knows the schema.
+
+import type { IngestResult, NormalizedEvent } from './types';
+
+// LOOP-150 retention window. Purge job uses expires_at.
+const EXPIRES_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+
+function computeExpiresAt(endDatetime: string | null, startDatetime: string): string {
+  const base = endDatetime ?? startDatetime;
+  return new Date(new Date(base).getTime() + EXPIRES_AFTER_MS).toISOString();
+}
+
+// Only sources with a numeric org id write to organizations. See
+// docs/org-profiles.md.
+async function upsertOrganization(db: D1Database, event: NormalizedEvent): Promise<void> {
+  if (event.organization.sourceOrgId === null) return;
+  await db
+    .prepare(
+      `INSERT INTO organizations (id, name, profile_picture, source, updated_at)
+       VALUES (?, ?, ?, ?, datetime('now'))
+       ON CONFLICT(id) DO UPDATE SET
+         name = excluded.name,
+         profile_picture = excluded.profile_picture,
+         updated_at = datetime('now')`,
+    )
+    .bind(
+      event.organization.sourceOrgId,
+      event.organization.name.trim(),
+      event.organization.profilePicture,
+      event.source,
+    )
+    .run();
+}
+
+async function upsertEvent(
+  db: D1Database,
+  event: NormalizedEvent,
+): Promise<{ eventId: number; isNew: boolean }> {
+  const expiresAt = computeExpiresAt(event.endDatetime, event.startDatetime);
+  const hostOrgId = event.organization.sourceOrgId;
+  const hostOrgName = event.organization.name.trim();
+
+  const existing = await db
+    .prepare(`SELECT id FROM events WHERE source = ? AND source_event_id = ?`)
+    .bind(event.source, event.sourceEventId)
+    .first();
+
+  if (existing) {
+    await db
+      .prepare(
+        `UPDATE events SET
+          title = ?, description = ?, start_datetime = ?, end_datetime = ?,
+          location_short = ?, location_full = ?, latitude = ?, longitude = ?,
+          host_organization_id = ?, host_organization_name = ?,
+          event_url = ?, rsvp_url = ?,
+          image_url = ?, image_width = ?, image_height = ?,
+          image_aspect_ratio = ?, image_mime_type = ?, image_alt_text = ?,
+          theme = ?, visibility = ?, rsvp_total = ?, expires_at = ?,
+          status = 'active', updated_at = datetime('now')
+        WHERE source = ? AND source_event_id = ?`,
+      )
+      .bind(
+        event.title,
+        event.description,
+        event.startDatetime,
+        event.endDatetime,
+        event.locationShort,
+        event.locationFull,
+        event.latitude,
+        event.longitude,
+        hostOrgId,
+        hostOrgName,
+        event.eventUrl,
+        event.rsvpUrl,
+        event.imageUrl,
+        event.imageWidth,
+        event.imageHeight,
+        event.imageAspectRatio,
+        event.imageMimeType,
+        event.imageAltText,
+        event.theme,
+        event.visibility,
+        event.rsvpTotal,
+        expiresAt,
+        event.source,
+        event.sourceEventId,
+      )
+      .run();
+
+    return { eventId: existing.id as number, isNew: false };
+  }
+
+  const result = await db
+    .prepare(
+      `INSERT INTO events (
+        source, source_event_id, title, description,
+        start_datetime, end_datetime, location_short, location_full,
+        latitude, longitude, host_organization_id, host_organization_name,
+        event_url, rsvp_url,
+        image_url, image_width, image_height,
+        image_aspect_ratio, image_mime_type, image_alt_text,
+        theme, visibility, rsvp_total, expires_at, status
+      ) VALUES (
+        ?, ?, ?, ?,
+        ?, ?, ?, ?,
+        ?, ?, ?, ?,
+        ?, ?,
+        ?, ?, ?,
+        ?, ?, ?,
+        ?, ?, ?, ?, 'active'
+      )`,
+    )
+    .bind(
+      event.source,
+      event.sourceEventId,
+      event.title,
+      event.description,
+      event.startDatetime,
+      event.endDatetime,
+      event.locationShort,
+      event.locationFull,
+      event.latitude,
+      event.longitude,
+      hostOrgId,
+      hostOrgName,
+      event.eventUrl,
+      event.rsvpUrl,
+      event.imageUrl,
+      event.imageWidth,
+      event.imageHeight,
+      event.imageAspectRatio,
+      event.imageMimeType,
+      event.imageAltText,
+      event.theme,
+      event.visibility,
+      event.rsvpTotal,
+      expiresAt,
+    )
+    .run();
+
+  return { eventId: result.meta.last_row_id as number, isNew: true };
+}
+
+async function replaceCategoriesAndBenefits(
+  db: D1Database,
+  eventId: number,
+  event: NormalizedEvent,
+): Promise<void> {
+  await db.prepare(`DELETE FROM event_categories WHERE event_id = ?`).bind(eventId).run();
+  await db.prepare(`DELETE FROM event_benefits WHERE event_id = ?`).bind(eventId).run();
+
+  for (const cat of event.categories) {
+    await db
+      .prepare(
+        `INSERT OR IGNORE INTO event_categories (event_id, category_id, category_name)
+         VALUES (?, ?, ?)`,
+      )
+      .bind(eventId, cat.id, cat.name)
+      .run();
+  }
+
+  for (const benefit of event.benefits) {
+    await db
+      .prepare(
+        `INSERT OR IGNORE INTO event_benefits (event_id, benefit_name)
+         VALUES (?, ?)`,
+      )
+      .bind(eventId, benefit)
+      .run();
+  }
+}
+
+// Per-event errors are isolated so one bad row doesn't sink the batch.
+export async function ingestEvents(
+  db: D1Database,
+  events: NormalizedEvent[],
+): Promise<IngestResult> {
+  const result: IngestResult = { inserted: 0, updated: 0, errors: [] };
+
+  for (const event of events) {
+    try {
+      await upsertOrganization(db, event);
+      const { eventId, isNew } = await upsertEvent(db, event);
+      await replaceCategoriesAndBenefits(db, eventId, event);
+      if (isNew) result.inserted++;
+      else result.updated++;
+    } catch (err) {
+      const msg = `Failed to ingest event ${event.source}:${event.sourceEventId} ("${event.title}"): ${err}`;
+      console.error(`[ingest] ${msg}`);
+      result.errors.push(msg);
+    }
+  }
+
+  return result;
+}

--- a/server/src/events/normalize.ts
+++ b/server/src/events/normalize.ts
@@ -1,0 +1,143 @@
+// Source-agnostic cleanup helpers used by scraper toNormalizedEvent() mappers.
+
+import { fetchWithRetry } from './polite-fetch';
+import type { ImageAspectRatio } from './types';
+
+export function stripHtml(html: string | null): string | null {
+  if (!html) return null;
+  return html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&mdash;/g, '—')
+    .replace(/&ndash;/g, '–')
+    .replace(/&hellip;/g, '…')
+    .replace(/&rsquo;/g, "'")
+    .replace(/&lsquo;/g, "'")
+    .replace(/&rdquo;/g, '”')
+    .replace(/&ldquo;/g, '“')
+    .replace(/&oacute;/g, 'ó')
+    .replace(/&le;/g, '≤')
+    .replace(/&ge;/g, '≥')
+    .replace(/&times;/g, '×')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function truncateLocation(location: string | null, maxLength = 40): string | null {
+  if (!location) return null;
+  if (location.length <= maxLength) return location;
+  return location.substring(0, maxLength - 3) + '...';
+}
+
+// tolerance is the +/- band around 1.0 that still counts as "square".
+// Default 0.2 for scrapers with unreliable dimensions. Scrapers that read
+// real image headers (McCombs) can pass a tighter value like 0.05.
+export function classifyAspectRatio(
+  width: number | null | undefined,
+  height: number | null | undefined,
+  hasImage: boolean,
+  tolerance: number = 0.2,
+): ImageAspectRatio {
+  if (!hasImage) return 'none';
+  if (!width || !height || width <= 0 || height <= 0) return 'square';
+  const ratio = width / height;
+  if (ratio > 1 + tolerance) return 'horizontal';
+  if (ratio < 1 - tolerance) return 'vertical';
+  return 'square';
+}
+
+export function buildAbsoluteUrl(base: string, path: string | null): string | null {
+  if (!path) return null;
+  return `${base}${path}`;
+}
+
+export function parseCoordinate(raw: string | null): number | null {
+  if (raw === null || raw === undefined || raw === '') return null;
+  const n = parseFloat(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+// Read width/height directly from PNG, GIF, or JPEG header bytes.
+// Lets us know the shape without downloading the whole file.
+export function parseImageDimensions(bytes: Uint8Array): { width: number; height: number } | null {
+  // PNG: 8-byte signature, then IHDR with width at offset 16, height at 20 (BE uint32).
+  if (
+    bytes.length >= 24 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    return { width: view.getUint32(16), height: view.getUint32(20) };
+  }
+
+  // GIF: 6-byte signature, then width at offset 6, height at 8 (LE uint16).
+  if (bytes.length >= 10 && bytes[0] === 0x47 && bytes[1] === 0x49 && bytes[2] === 0x46) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    return { width: view.getUint16(6, true), height: view.getUint16(8, true) };
+  }
+
+  // JPEG: walk segments looking for a Start-Of-Frame marker (0xC0 to 0xCF,
+  // excluding 0xC4/0xC8/0xCC which mean other things).
+  if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    let offset = 2;
+    while (offset + 9 < bytes.length) {
+      if (bytes[offset] !== 0xff) {
+        offset++;
+        continue;
+      }
+      const marker = bytes[offset + 1];
+      if (
+        marker >= 0xc0 &&
+        marker <= 0xcf &&
+        marker !== 0xc4 &&
+        marker !== 0xc8 &&
+        marker !== 0xcc
+      ) {
+        return {
+          height: view.getUint16(offset + 5),
+          width: view.getUint16(offset + 7),
+        };
+      }
+      const segmentLength = view.getUint16(offset + 2);
+      offset += 2 + segmentLength;
+    }
+  }
+
+  return null;
+}
+
+export interface ImageMeta {
+  width: number | null;
+  height: number | null;
+  mimeType: string | null;
+}
+
+// Range-reads the first 64KB of an image. Enough for the header without
+// downloading a multi-MB flyer. Returns nulls on any failure so callers
+// can fall back to unknown dimensions. logTag identifies which scraper
+// is calling for cleaner log lines.
+export async function fetchImageMeta(
+  imageUrl: string,
+  logTag: string = 'image-meta',
+): Promise<ImageMeta> {
+  try {
+    const res = await fetchWithRetry(imageUrl, {
+      headers: { Accept: '*/*', Range: 'bytes=0-65535' },
+    });
+    const mimeType = res.headers.get('content-type');
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    const dims = parseImageDimensions(bytes);
+    return { width: dims?.width ?? null, height: dims?.height ?? null, mimeType };
+  } catch (err) {
+    console.warn(`[${logTag}] Failed to read image metadata for ${imageUrl}: ${err}`);
+    return { width: null, height: null, mimeType: null };
+  }
+}

--- a/server/src/events/polite-fetch.ts
+++ b/server/src/events/polite-fetch.ts
@@ -1,0 +1,62 @@
+// Shared HTTP helpers for scrapers.
+//
+// What this gives us:
+//   - Exponential backoff on HTTP 429 (rate limited): 2s, 4s, 8s...
+//   - Retry on network errors / thrown exceptions
+//   - A consistent User-Agent identifying us as Longhorn Loop
+//   - Throws on 4xx/5xx responses so callers can .catch() cleanly
+//
+// Sleep is exported for scrapers that need a delay between page fetches
+// on top of the retry-side backoff.
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_USER_AGENT = 'LonghornLoop/1.0 (+https://longhornloop.app)';
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export interface FetchWithRetryOptions {
+  retries?: number;
+  userAgent?: string;
+  // Passed through to fetch(). Merged on top of the default Accept + UA.
+  headers?: Record<string, string>;
+}
+
+export async function fetchWithRetry(
+  url: string,
+  options: FetchWithRetryOptions = {},
+): Promise<Response> {
+  const retries = options.retries ?? DEFAULT_MAX_RETRIES;
+  const userAgent = options.userAgent ?? DEFAULT_USER_AGENT;
+
+  for (let attempt = 0; attempt < retries; attempt++) {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': userAgent,
+          ...options.headers,
+        },
+      });
+
+      if (res.status === 429) {
+        const backoff = Math.pow(2, attempt) * 2000;
+        console.log(`[polite-fetch] 429 from ${url}, backing off ${backoff}ms...`);
+        await sleep(backoff);
+        continue;
+      }
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+      return res;
+    } catch (err) {
+      if (attempt === retries - 1) throw err;
+      const backoff = Math.pow(2, attempt) * 1000;
+      console.log(
+        `[polite-fetch] attempt ${attempt + 1} failed for ${url}, retrying in ${backoff}ms...`,
+      );
+      await sleep(backoff);
+    }
+  }
+  throw new Error('All retries exhausted');
+}

--- a/server/src/events/types.ts
+++ b/server/src/events/types.ts
@@ -1,0 +1,56 @@
+// Shape every scraper produces and every ingest call consumes.
+
+export type ImageAspectRatio = 'vertical' | 'square' | 'horizontal' | 'none';
+
+export interface NormalizedOrganization {
+  // Null for sources that only expose department names (Texas Today, McCombs).
+  // When null, ingest.ts skips the organizations upsert and stores only the
+  // department name on the event row. See docs/org-profiles.md for the
+  // reasoning + plan for eventually giving departments claimable pages.
+  sourceOrgId: number | null;
+  name: string;
+  profilePicture: string | null;
+}
+
+export interface NormalizedEvent {
+  source: string;
+  sourceEventId: string;
+
+  title: string;
+  description: string | null;
+  startDatetime: string;
+  endDatetime: string | null;
+
+  locationShort: string | null;
+  locationFull: string | null;
+  latitude: number | null;
+  longitude: number | null;
+
+  organization: NormalizedOrganization;
+
+  eventUrl: string;
+  rsvpUrl: string | null;
+
+  imageUrl: string | null;
+  imageAspectRatio: ImageAspectRatio;
+  // McCombs: always set (parsed from the image header byte range).
+  // Texas Today: sometimes set (Localist returns them on newer uploads).
+  // HornsLink: never set.
+  imageWidth: number | null;
+  imageHeight: number | null;
+  imageMimeType: string | null;
+  imageAltText: string | null;
+
+  theme: string | null;
+  visibility: string;
+  rsvpTotal: number;
+
+  categories: { id: string; name: string | null }[];
+  benefits: string[];
+}
+
+export interface IngestResult {
+  inserted: number;
+  updated: number;
+  errors: string[];
+}

--- a/server/src/routes/events.worker.ts
+++ b/server/src/routes/events.worker.ts
@@ -1,8 +1,8 @@
 // Events routes for Cloudflare Worker
-import { Hono } from "hono";
-import { scrapeHornsLink } from "../scrapers/hornslink";
-import { scrapeMccombs } from "../scrapers/mccombs";
-import type { Env } from "../worker";
+import { Hono } from 'hono';
+import { scrapeHornsLink } from '../scrapers/hornslink';
+import { scrapeMccombs } from '../scrapers/mccombs';
+import type { Env } from '../worker';
 
 export const eventRoutes = new Hono<{ Bindings: Env }>();
 
@@ -286,7 +286,7 @@ eventRoutes.post('/scrape', async (c) => {
 });
 
 // POST /events/scrape/mccombs -- manually trigger the McCombs scrape (for testing)
-eventRoutes.post("/scrape/mccombs", async (c) => {
+eventRoutes.post('/scrape/mccombs', async (c) => {
   const body = await c.req.json().catch(() => ({}));
   const maxEvents = (body as any).maxEvents ?? 500;
   const dryRun = (body as any).dryRun ?? false;

--- a/server/src/scrapers/hornslink.ts
+++ b/server/src/scrapers/hornslink.ts
@@ -1,16 +1,20 @@
-/**
- * HornsLink Event Scraper
- *
- * Fetches events from UT Austin's HornsLink (Campus Labs Engage) platform
- * via their public discovery API. No authentication required.
- *
- * API base: https://utexas.campuslabs.com/engage/api/discovery/event/search
- * Image base: https://se-images.campuslabs.com/clink/images/
- */
+// HornsLink scraper. Public discovery API, no auth.
+// API:   https://utexas.campuslabs.com/engage/api/discovery/event/search
+// Images: https://se-images.campuslabs.com/clink/images/
 
+import { ingestEvents } from '../events/ingest';
+import {
+  buildAbsoluteUrl,
+  classifyAspectRatio,
+  parseCoordinate,
+  stripHtml,
+  truncateLocation,
+} from '../events/normalize';
+import { fetchWithRetry, sleep } from '../events/polite-fetch';
+import type { NormalizedEvent } from '../events/types';
 import type { Env } from '../worker';
 
-// ---------- Types ----------
+// Types
 
 interface HornsLinkEvent {
   id: string;
@@ -39,11 +43,6 @@ interface HornsLinkEvent {
 
 interface HornsLinkSearchResponse {
   '@odata.count': number;
-  '@search.facets': {
-    CategoryIds: Array<{ value: string; count: number }>;
-    BenefitNames: Array<{ value: string; count: number }>;
-    Theme: Array<{ value: string; count: number }>;
-  };
   value: HornsLinkEvent[];
 }
 
@@ -56,106 +55,33 @@ interface ScraperResult {
   durationMs: number;
 }
 
-// ---------- Constants ----------
+// Constants
 
 const HORNSLINK_API_BASE = 'https://utexas.campuslabs.com/engage/api/discovery/event/search';
 const HORNSLINK_EVENT_URL_BASE = 'https://utexas.campuslabs.com/engage/event/';
 const IMAGE_BASE_URL = 'https://se-images.campuslabs.com/clink/images/';
-const ORG_PROFILE_IMAGE_BASE = 'https://se-images.campuslabs.com/clink/images/';
 
-// Polite scraping settings
 const PAGE_SIZE = 20;
-const MAX_PAGES = 5; // Start small: 100 events max
-const REQUEST_DELAY_MS = 500; // 500ms between requests
-const MAX_RETRIES = 3;
+const MAX_PAGES = 5;
+const REQUEST_DELAY_MS = 500;
 const DAYS_AHEAD = 30;
 
-// Cron settings: 25 pages * 20/page = up to 500 events, matching the
-// 200-500 events/run target for the scheduled scrape.
+// Cron: 25 pages * 20 = up to 500 events, matching the target run size.
 const CRON_MAX_PAGES = 25;
-// Stay well under the Workers CPU/wall-clock limit for scheduled handlers —
-// if we run long, stop early and pick up the remaining pages next run
-// (safe because results are ordered by endsOn ascending, so we always make
-// progress on the soonest-ending events first).
+// Stop early if we're close to the Workers CPU budget. Results are
+// ordered by endsOn asc, so soonest-ending events get done first and
+// leftovers roll to the next run.
 const TIME_BUDGET_MS = 25_000;
 
-// ---------- Helpers ----------
+// Helpers
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-/**
- * Truncate location to 40 chars for card display
- */
-function truncateLocation(location: string | null): string | null {
-  if (!location) return null;
-  return location.length > 40 ? location.substring(0, 37) + '...' : location;
-}
-
-/**
- * Classify image aspect ratio based on dimensions.
- * If we don't have dimensions, return 'none' for null images or 'square' as default.
- */
-function classifyAspectRatio(
-  width: number | null,
-  height: number | null,
-  hasImage: boolean,
-): string {
-  if (!hasImage) return 'none';
-  if (!width || !height) return 'square'; // default when dimensions unknown
-  const ratio = width / height;
-  if (ratio < 0.8) return 'vertical';
-  if (ratio > 1.2) return 'horizontal';
-  return 'square';
-}
-
-/**
- * Build the full image URL from HornsLink image path
- */
-function buildImageUrl(imagePath: string | null): string | null {
-  if (!imagePath) return null;
-  return `${IMAGE_BASE_URL}${imagePath}`;
-}
-
-/**
- * Strip HTML tags from description for clean text
- */
-function stripHtml(html: string | null): string | null {
-  if (!html) return null;
-  return html
-    .replace(/<[^>]*>/g, '')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&mdash;/g, '—')
-    .replace(/&rsquo;/g, "'")
-    .replace(/&lsquo;/g, "'")
-    .replace(/&rdquo;/g, '\u201D')
-    .replace(/&ldquo;/g, '\u201C')
-    .replace(/&oacute;/g, 'ó')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-/**
- * Build the search URL for a given page
- */
 function buildSearchUrl(page: number): string {
   const now = new Date();
-  const startsAfter = now.toISOString();
-  // Look DAYS_AHEAD days ahead. The API doesn't reliably honor an upper
-  // bound param, so this is a best-effort hint — the real enforcement
-  // happens client-side in scrapeHornsLink via the endsOn cutoff check.
   const endDate = new Date(now.getTime() + DAYS_AHEAD * 24 * 60 * 60 * 1000);
-  const endsBefore = endDate.toISOString();
 
   const params = new URLSearchParams({
-    endsAfter: startsAfter,
-    endsBefore,
+    endsAfter: now.toISOString(),
+    endsBefore: endDate.toISOString(),
     orderByField: 'endsOn',
     orderByDirection: 'ascending',
     status: 'Approved',
@@ -166,203 +92,50 @@ function buildSearchUrl(page: number): string {
   return `${HORNSLINK_API_BASE}?${params.toString()}`;
 }
 
-// ---------- Fetch with retry ----------
+// Normalize
 
-async function fetchWithRetry(url: string, retries = MAX_RETRIES): Promise<Response> {
-  for (let attempt = 0; attempt < retries; attempt++) {
-    try {
-      const res = await fetch(url, {
-        headers: {
-          Accept: 'application/json',
-          'User-Agent': 'LonghornLoop/1.0 (student-project)',
-        },
-      });
+function toNormalizedEvent(raw: HornsLinkEvent): NormalizedEvent {
+  const imageUrl = buildAbsoluteUrl(IMAGE_BASE_URL, raw.imagePath);
+  const profilePicture = buildAbsoluteUrl(IMAGE_BASE_URL, raw.organizationProfilePicture);
 
-      if (res.status === 429) {
-        // Rate limited — back off exponentially
-        const backoff = Math.pow(2, attempt) * 2000;
-        console.log(`Rate limited, backing off ${backoff}ms...`);
-        await sleep(backoff);
-        continue;
-      }
+  const categories = raw.categoryIds.map((id, i) => ({
+    id,
+    name: raw.categoryNames[i] ?? null,
+  }));
 
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-      }
-
-      return res;
-    } catch (err) {
-      if (attempt === retries - 1) throw err;
-      const backoff = Math.pow(2, attempt) * 1000;
-      console.log(`Attempt ${attempt + 1} failed, retrying in ${backoff}ms...`);
-      await sleep(backoff);
-    }
-  }
-  throw new Error('All retries exhausted');
+  return {
+    source: 'hornslink',
+    sourceEventId: raw.id,
+    title: raw.name,
+    description: stripHtml(raw.description),
+    startDatetime: raw.startsOn,
+    endDatetime: raw.endsOn,
+    locationShort: truncateLocation(raw.location),
+    locationFull: raw.location,
+    latitude: parseCoordinate(raw.latitude),
+    longitude: parseCoordinate(raw.longitude),
+    organization: {
+      sourceOrgId: raw.organizationId,
+      name: raw.organizationName,
+      profilePicture,
+    },
+    eventUrl: `${HORNSLINK_EVENT_URL_BASE}${raw.id}`,
+    rsvpUrl: null,
+    imageUrl,
+    imageAspectRatio: classifyAspectRatio(null, null, !!imageUrl),
+    imageWidth: null,
+    imageHeight: null,
+    imageMimeType: null,
+    imageAltText: null,
+    theme: raw.theme,
+    visibility: raw.visibility,
+    rsvpTotal: raw.rsvpTotal,
+    categories,
+    benefits: raw.benefitNames,
+  };
 }
 
-// ---------- Database Operations ----------
-
-async function upsertOrganization(db: D1Database, event: HornsLinkEvent): Promise<void> {
-  const profilePicUrl = event.organizationProfilePicture
-    ? `${ORG_PROFILE_IMAGE_BASE}${event.organizationProfilePicture}`
-    : null;
-
-  await db
-    .prepare(
-      `INSERT INTO organizations (id, name, profile_picture, source, updated_at)
-       VALUES (?, ?, ?, 'hornslink', datetime('now'))
-       ON CONFLICT(id) DO UPDATE SET
-         name = excluded.name,
-         profile_picture = excluded.profile_picture,
-         updated_at = datetime('now')`,
-    )
-    .bind(event.organizationId, event.organizationName.trim(), profilePicUrl)
-    .run();
-}
-
-// Purge target for the cleanup job (LOOP-150): end time + 7 days, falling
-// back to the start time when an event has no end time.
-const EXPIRES_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
-
-function computeExpiresAt(endsOn: string | null, startsOn: string): string {
-  const base = endsOn ?? startsOn;
-  return new Date(new Date(base).getTime() + EXPIRES_AFTER_MS).toISOString();
-}
-
-async function upsertEvent(db: D1Database, event: HornsLinkEvent): Promise<{ isNew: boolean }> {
-  const imageUrl = buildImageUrl(event.imagePath);
-  const aspectRatio = classifyAspectRatio(null, null, !!event.imagePath);
-  const locationShort = truncateLocation(event.location);
-  const eventUrl = `${HORNSLINK_EVENT_URL_BASE}${event.id}`;
-  const cleanDescription = stripHtml(event.description);
-  const expiresAt = computeExpiresAt(event.endsOn, event.startsOn);
-
-  // Check if event already exists
-  const existing = await db
-    .prepare("SELECT id FROM events WHERE source = 'hornslink' AND source_event_id = ?")
-    .bind(event.id)
-    .first();
-
-  if (existing) {
-    // Update existing event
-    await db
-      .prepare(
-        `UPDATE events SET
-          title = ?, description = ?, start_datetime = ?, end_datetime = ?,
-          location_short = ?, location_full = ?, latitude = ?, longitude = ?,
-          host_organization_id = ?, host_organization_name = ?,
-          event_url = ?, image_url = ?, image_aspect_ratio = ?,
-          theme = ?, visibility = ?, rsvp_total = ?, expires_at = ?,
-          status = 'active', updated_at = datetime('now')
-        WHERE source = 'hornslink' AND source_event_id = ?`,
-      )
-      .bind(
-        event.name,
-        cleanDescription,
-        event.startsOn,
-        event.endsOn,
-        locationShort,
-        event.location,
-        event.latitude ? parseFloat(event.latitude) : null,
-        event.longitude ? parseFloat(event.longitude) : null,
-        event.organizationId,
-        event.organizationName.trim(),
-        eventUrl,
-        imageUrl,
-        aspectRatio,
-        event.theme,
-        event.visibility,
-        event.rsvpTotal,
-        expiresAt,
-        event.id,
-      )
-      .run();
-
-    // Clear and re-insert categories and benefits
-    const eventId = existing.id as number;
-    await db.prepare('DELETE FROM event_categories WHERE event_id = ?').bind(eventId).run();
-    await db.prepare('DELETE FROM event_benefits WHERE event_id = ?').bind(eventId).run();
-
-    await insertCategoriesAndBenefits(db, eventId, event);
-
-    return { isNew: false };
-  } else {
-    // Insert new event
-    const result = await db
-      .prepare(
-        `INSERT INTO events (
-          source, source_event_id, title, description,
-          start_datetime, end_datetime, location_short, location_full,
-          latitude, longitude, host_organization_id, host_organization_name,
-          event_url, image_url, image_aspect_ratio, theme,
-          visibility, rsvp_total, expires_at, status
-        ) VALUES (
-          'hornslink', ?, ?, ?,
-          ?, ?, ?, ?,
-          ?, ?, ?, ?,
-          ?, ?, ?, ?,
-          ?, ?, ?, 'active'
-        )`,
-      )
-      .bind(
-        event.id,
-        event.name,
-        cleanDescription,
-        event.startsOn,
-        event.endsOn,
-        locationShort,
-        event.location,
-        event.latitude ? parseFloat(event.latitude) : null,
-        event.longitude ? parseFloat(event.longitude) : null,
-        event.organizationId,
-        event.organizationName.trim(),
-        eventUrl,
-        imageUrl,
-        aspectRatio,
-        event.theme,
-        event.visibility,
-        event.rsvpTotal,
-        expiresAt,
-      )
-      .run();
-
-    const eventId = result.meta.last_row_id;
-    await insertCategoriesAndBenefits(db, eventId, event);
-
-    return { isNew: true };
-  }
-}
-
-async function insertCategoriesAndBenefits(
-  db: D1Database,
-  eventId: number,
-  event: HornsLinkEvent,
-): Promise<void> {
-  // Insert categories
-  for (let i = 0; i < event.categoryIds.length; i++) {
-    await db
-      .prepare(
-        `INSERT OR IGNORE INTO event_categories (event_id, category_id, category_name)
-         VALUES (?, ?, ?)`,
-      )
-      .bind(eventId, event.categoryIds[i], event.categoryNames[i] || null)
-      .run();
-  }
-
-  // Insert benefits/perks
-  for (const benefit of event.benefitNames) {
-    await db
-      .prepare(
-        `INSERT OR IGNORE INTO event_benefits (event_id, benefit_name)
-         VALUES (?, ?)`,
-      )
-      .bind(eventId, benefit)
-      .run();
-  }
-}
-
-// ---------- Main Scraper ----------
+// Main scraper
 
 export async function scrapeHornsLink(
   db: D1Database,
@@ -388,7 +161,7 @@ export async function scrapeHornsLink(
   for (let page = 0; page < maxPages; page++) {
     if (page > 0 && Date.now() - startTime > timeBudgetMs) {
       console.warn(
-        `[HornsLink] Time budget (${timeBudgetMs}ms) exceeded after page ${page}, stopping early. Remaining pages will be picked up next run.`,
+        `[HornsLink] Time budget (${timeBudgetMs}ms) exceeded after page ${page}, stopping early.`,
       );
       break;
     }
@@ -409,51 +182,37 @@ export async function scrapeHornsLink(
         `[HornsLink] Got ${data.value.length} events (total available: ${data['@odata.count']})`,
       );
 
-      // Process each event with error isolation
-      for (const event of data.value) {
-        try {
-          result.eventsProcessed++;
-
-          // Defense in depth: enforce the 30-day window client-side in case
-          // the API ignores the endsBefore hint.
-          const startMs = new Date(event.startsOn).getTime();
-          if (!isNaN(startMs) && startMs > cutoffMs) {
-            result.eventsSkipped++;
-            continue;
-          }
-
-          if (dryRun) {
-            console.log(
-              `[DRY RUN] Event: "${event.name}" by ${event.organizationName} @ ${event.location || 'TBD'} on ${event.startsOn}`,
-            );
-            continue;
-          }
-
-          // Upsert org first (foreign key)
-          await upsertOrganization(db, event);
-
-          // Upsert event
-          const { isNew } = await upsertEvent(db, event);
-          if (isNew) {
-            result.eventsInserted++;
-          } else {
-            result.eventsUpdated++;
-          }
-        } catch (err) {
-          const errorMsg = `Failed to process event ${event.id} ("${event.name}"): ${err}`;
-          console.error(`[HornsLink] ${errorMsg}`);
-          result.errors.push(errorMsg);
+      // Client-side cutoff enforcement in case the API ignores endsBefore.
+      const inWindow: HornsLinkEvent[] = [];
+      for (const raw of data.value) {
+        result.eventsProcessed++;
+        const startMs = new Date(raw.startsOn).getTime();
+        if (!isNaN(startMs) && startMs > cutoffMs) {
+          result.eventsSkipped++;
+          continue;
         }
+        inWindow.push(raw);
       }
 
-      // Polite delay between pages
-      if (page < maxPages - 1) {
-        await sleep(REQUEST_DELAY_MS);
+      if (dryRun) {
+        for (const raw of inWindow) {
+          console.log(
+            `[DRY RUN] "${raw.name}" by ${raw.organizationName} @ ${raw.location || 'TBD'} on ${raw.startsOn}`,
+          );
+        }
+      } else {
+        const normalized = inWindow.map(toNormalizedEvent);
+        const ingested = await ingestEvents(db, normalized);
+        result.eventsInserted += ingested.inserted;
+        result.eventsUpdated += ingested.updated;
+        result.errors.push(...ingested.errors);
       }
+
+      if (page < maxPages - 1) await sleep(REQUEST_DELAY_MS);
     } catch (err) {
-      const errorMsg = `Failed to fetch page ${page + 1}: ${err}`;
-      console.error(`[HornsLink] ${errorMsg}`);
-      result.errors.push(errorMsg);
+      const msg = `Failed to fetch page ${page + 1}: ${err}`;
+      console.error(`[HornsLink] ${msg}`);
+      result.errors.push(msg);
     }
   }
 
@@ -469,16 +228,10 @@ export async function scrapeHornsLink(
   return result;
 }
 
-/**
- * Cron entrypoint — called by the scheduled handler in worker.ts every 6h.
- * Uses a larger page budget than the manual /events/scrape route to reach
- * the 200-500 events/run target.
- */
+// Cron entrypoint. Larger page budget than the manual scrape route.
 export async function run(env: Env): Promise<void> {
   console.log('[HornsLink] Cron scrape started');
-
   const result = await scrapeHornsLink(env.DB, { maxPages: CRON_MAX_PAGES });
-
   if (result.errors.length > 0) {
     console.error(
       `[HornsLink] Cron run had ${result.errors.length} event-level error(s):`,

--- a/server/src/scrapers/mccombs.test.ts
+++ b/server/src/scrapers/mccombs.test.ts
@@ -1,228 +1,229 @@
-import { describe, expect, it } from "vitest";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { classifyAspectRatio, parseImageDimensions } from '../events/normalize';
 import {
   buildLocationFull,
   buildLocationShort,
-  classifyAspectRatio,
   cleanHostOrganization,
   decodeHtmlEntities,
   extractLocs,
+  extractMccombsEventId,
   extractRsvpUrl,
-  extractSourceEventId,
   parseEventFromHtml,
-  parseImageDimensions,
   upgradeImageUrl,
-} from "./mccombs";
+} from './mccombs';
 
 function loadFixture(name: string): string {
-  return readFileSync(join(__dirname, "__fixtures__", "mccombs", name), "utf-8");
+  return readFileSync(join(__dirname, '__fixtures__', 'mccombs', name), 'utf-8');
 }
 
-describe("parseEventFromHtml", () => {
-  it("parses a standard event with a flyer image", () => {
-    const parsed = parseEventFromHtml(loadFixture("standard.html"), "https://example.com");
+describe('parseEventFromHtml', () => {
+  it('parses a standard event with a flyer image', () => {
+    const parsed = parseEventFromHtml(loadFixture('standard.html'), 'https://example.com');
     expect(parsed).not.toBeNull();
-    expect(parsed?.source).toBe("mccombs");
-    expect(parsed?.source_event_id).toBe("12001");
-    expect(parsed?.title).toBe("MSITM Lunch and Learn: Data Careers");
-    expect(parsed?.start_datetime).toBe("2026-09-15T17:00:00+00:00");
-    expect(parsed?.end_datetime).toBe("2026-09-15T18:00:00+00:00");
-    expect(parsed?.host_organization_name).toBe("MSITM");
-    expect(parsed?.location_short).toBe("GSB 2.122");
-    expect(parsed?.location_full).toBe("GSB 2.122, 2110 Speedway, Austin, TX 78705");
-    expect(parsed?.image_url).toBe(
-      "https://calendar.mccombs.utexas.edu/live/image/gid/9/lunch-and-learn-flyer.jpg",
+    expect(parsed?.source).toBe('mccombs');
+    expect(parsed?.sourceEventId).toBe('12001');
+    expect(parsed?.title).toBe('MSITM Lunch and Learn: Data Careers');
+    expect(parsed?.startDatetime).toBe('2026-09-15T17:00:00+00:00');
+    expect(parsed?.endDatetime).toBe('2026-09-15T18:00:00+00:00');
+    expect(parsed?.organization.name).toBe('MSITM');
+    expect(parsed?.organization.sourceOrgId).toBeNull();
+    expect(parsed?.locationShort).toBe('GSB 2.122');
+    expect(parsed?.locationFull).toBe('GSB 2.122, 2110 Speedway, Austin, TX 78705');
+    expect(parsed?.imageUrl).toBe(
+      'https://calendar.mccombs.utexas.edu/live/image/gid/9/lunch-and-learn-flyer.jpg',
     );
-    expect(parsed?.rsvp_url).toBeNull();
+    expect(parsed?.rsvpUrl).toBeNull();
   });
 
-  it("handles an RSVP-required event with no image and no explicit link", () => {
-    const parsed = parseEventFromHtml(loadFixture("rsvp-required.html"), "https://example.com");
+  it('handles an RSVP-required event with no image and no explicit link', () => {
+    const parsed = parseEventFromHtml(loadFixture('rsvp-required.html'), 'https://example.com');
     expect(parsed).not.toBeNull();
-    expect(parsed?.host_organization_name).toBe("Herb Kelleher Center");
-    expect(parsed?.description).toContain("RSVP required");
-    expect(parsed?.description).not.toContain("&amp;");
-    expect(parsed?.image_url).toBeNull();
-    expect(parsed?.image_aspect_ratio).toBe("none");
-    expect(parsed?.rsvp_url).toBeNull();
+    expect(parsed?.organization.name).toBe('Herb Kelleher Center');
+    expect(parsed?.description).toContain('RSVP required');
+    expect(parsed?.description).not.toContain('&amp;');
+    expect(parsed?.imageUrl).toBeNull();
+    expect(parsed?.imageAspectRatio).toBe('none');
+    expect(parsed?.rsvpUrl).toBeNull();
   });
 
-  it("extracts a bare external registration URL from the description", () => {
+  it('extracts a bare external registration URL from the description', () => {
     const parsed = parseEventFromHtml(
-      loadFixture("external-registration.html"),
-      "https://example.com",
+      loadFixture('external-registration.html'),
+      'https://example.com',
     );
     expect(parsed).not.toBeNull();
-    expect(parsed?.rsvp_url).toBe(
-      "https://www.eventbrite.com/e/mccombs-partner-info-session-123456789",
+    expect(parsed?.rsvpUrl).toBe(
+      'https://www.eventbrite.com/e/mccombs-partner-info-session-123456789',
     );
-    expect(parsed?.location_short).toBe("Virtual Event");
+    expect(parsed?.locationShort).toBe('Virtual Event');
   });
 
-  it("handles an event with no flyer image", () => {
-    const parsed = parseEventFromHtml(loadFixture("no-flyer.html"), "https://example.com");
+  it('handles an event with no flyer image', () => {
+    const parsed = parseEventFromHtml(loadFixture('no-flyer.html'), 'https://example.com');
     expect(parsed).not.toBeNull();
-    expect(parsed?.image_url).toBeNull();
-    expect(parsed?.image_width).toBeNull();
-    expect(parsed?.image_aspect_ratio).toBe("none");
-    expect(parsed?.host_organization_name).toBe("Global Sustainability Leadership Institute");
+    expect(parsed?.imageUrl).toBeNull();
+    expect(parsed?.imageWidth).toBeNull();
+    expect(parsed?.imageAspectRatio).toBe('none');
+    expect(parsed?.organization.name).toBe('Global Sustainability Leadership Institute');
   });
 
-  it("returns null when no Event JSON-LD is present", () => {
-    const parsed = parseEventFromHtml("<html><body>no events here</body></html>", "https://example.com/foo");
+  it('returns null when no Event JSON-LD is present', () => {
+    const parsed = parseEventFromHtml(
+      '<html><body>no events here</body></html>',
+      'https://example.com/foo',
+    );
     expect(parsed).toBeNull();
   });
 });
 
-describe("cleanHostOrganization", () => {
-  it("strips the McCombs boilerplate suffix", () => {
+describe('cleanHostOrganization', () => {
+  it('strips the McCombs boilerplate suffix', () => {
     expect(
       cleanHostOrganization(
-        "Alumni Engagement (McCombs School of Business - The University of Texas at Austin)",
+        'Alumni Engagement (McCombs School of Business - The University of Texas at Austin)',
       ),
-    ).toBe("Alumni Engagement");
+    ).toBe('Alumni Engagement');
   });
 
   it("returns the name unchanged when there's no suffix to strip", () => {
-    expect(cleanHostOrganization("Harkey Institute")).toBe("Harkey Institute");
+    expect(cleanHostOrganization('Harkey Institute')).toBe('Harkey Institute');
   });
 
-  it("returns null for missing organizer", () => {
+  it('returns null for missing organizer', () => {
     expect(cleanHostOrganization(undefined)).toBeNull();
     expect(cleanHostOrganization(null)).toBeNull();
   });
 });
 
-describe("extractSourceEventId", () => {
-  it("extracts the numeric id from an event URL", () => {
+describe('extractMccombsEventId', () => {
+  it('extracts the numeric id from an event URL', () => {
     expect(
-      extractSourceEventId(
-        "https://calendar.mccombs.utexas.edu/alumni/event/11049-los-angeles-alumni-chapter",
+      extractMccombsEventId(
+        'https://calendar.mccombs.utexas.edu/alumni/event/11049-los-angeles-alumni-chapter',
       ),
-    ).toBe("11049");
+    ).toBe('11049');
   });
 
-  it("falls back to the URL path for vanity-slug events with no numeric id", () => {
+  it('falls back to the URL path for vanity-slug events with no numeric id', () => {
+    expect(extractMccombsEventId('https://calendar.mccombs.utexas.edu/event/career-expo')).toBe(
+      'event/career-expo',
+    );
     expect(
-      extractSourceEventId("https://calendar.mccombs.utexas.edu/event/career-expo"),
-    ).toBe("event/career-expo");
-    expect(
-      extractSourceEventId(
-        "https://calendar.mccombs.utexas.edu/recruiters-corporations/event/career-expo",
+      extractMccombsEventId(
+        'https://calendar.mccombs.utexas.edu/recruiters-corporations/event/career-expo',
       ),
-    ).toBe("recruiters-corporations/event/career-expo");
+    ).toBe('recruiters-corporations/event/career-expo');
   });
 
-  it("returns null for an unparseable URL with no path", () => {
-    expect(extractSourceEventId("not a url")).toBeNull();
+  it('returns null for an unparseable URL with no path', () => {
+    expect(extractMccombsEventId('not a url')).toBeNull();
   });
 });
 
-describe("buildLocationShort / buildLocationFull", () => {
-  it("takes the venue name before the first comma, truncated to 40 chars", () => {
-    expect(buildLocationShort("GSB 2.122, 2110 Speedway, Austin, TX 78705")).toBe("GSB 2.122");
+describe('buildLocationShort / buildLocationFull', () => {
+  it('takes the venue name before the first comma, truncated to 40 chars', () => {
+    expect(buildLocationShort('GSB 2.122, 2110 Speedway, Austin, TX 78705')).toBe('GSB 2.122');
   });
 
   it("falls back to the full string when there's no comma", () => {
-    expect(buildLocationShort("CBA 3.302")).toBe("CBA 3.302");
+    expect(buildLocationShort('CBA 3.302')).toBe('CBA 3.302');
   });
 
-  it("truncates long single-segment locations to 40 chars", () => {
-    const long = "Avalon Beverly Hills - 9400 West Olympic Blvd. Beverly Hills";
+  it('truncates long single-segment locations to 40 chars', () => {
+    const long = 'Avalon Beverly Hills - 9400 West Olympic Blvd. Beverly Hills';
     const short = buildLocationShort(long);
     expect(short?.length).toBeLessThanOrEqual(40);
-    expect(short?.endsWith("...")).toBe(true);
+    expect(short?.endsWith('...')).toBe(true);
   });
 
-  it("returns null for missing location", () => {
+  it('returns null for missing location', () => {
     expect(buildLocationShort(null)).toBeNull();
     expect(buildLocationFull(undefined)).toBeNull();
   });
 
-  it("decodes HTML entities in the full location", () => {
-    expect(buildLocationFull("AT&amp;T Hotel &amp; Conference Center")).toBe(
-      "AT&T Hotel & Conference Center",
+  it('decodes HTML entities in the full location', () => {
+    expect(buildLocationFull('AT&amp;T Hotel &amp; Conference Center')).toBe(
+      'AT&T Hotel & Conference Center',
     );
   });
 });
 
-describe("classifyAspectRatio", () => {
-  it("classifies horizontal, vertical, square, and none", () => {
-    expect(classifyAspectRatio(1200, 800)).toBe("horizontal");
-    expect(classifyAspectRatio(800, 1200)).toBe("vertical");
-    expect(classifyAspectRatio(1000, 1000)).toBe("square");
-    expect(classifyAspectRatio(null, null)).toBe("none");
-    expect(classifyAspectRatio(0, 0)).toBe("none");
+describe('classifyAspectRatio (with McCombs 5% tolerance)', () => {
+  it('classifies horizontal, vertical, square, and none', () => {
+    expect(classifyAspectRatio(1200, 800, true, 0.05)).toBe('horizontal');
+    expect(classifyAspectRatio(800, 1200, true, 0.05)).toBe('vertical');
+    expect(classifyAspectRatio(1000, 1000, true, 0.05)).toBe('square');
+    expect(classifyAspectRatio(null, null, false, 0.05)).toBe('none');
   });
 
-  it("uses a 5% tolerance band around square", () => {
-    expect(classifyAspectRatio(1030, 1000)).toBe("square");
-    expect(classifyAspectRatio(1060, 1000)).toBe("horizontal");
+  it('uses a 5% tolerance band around square', () => {
+    expect(classifyAspectRatio(1030, 1000, true, 0.05)).toBe('square');
+    expect(classifyAspectRatio(1060, 1000, true, 0.05)).toBe('horizontal');
   });
 });
 
-describe("upgradeImageUrl", () => {
-  it("strips the resize/crop path segment to get the original upload", () => {
+describe('upgradeImageUrl', () => {
+  it('strips the resize/crop path segment to get the original upload', () => {
     expect(
       upgradeImageUrl(
-        "https://calendar.mccombs.utexas.edu/live/image/gid/7/width/600/height/600/crop/1/src_region/0,0,2560,2560/74_KBH_Symposium.png",
+        'https://calendar.mccombs.utexas.edu/live/image/gid/7/width/600/height/600/crop/1/src_region/0,0,2560,2560/74_KBH_Symposium.png',
       ),
-    ).toBe("https://calendar.mccombs.utexas.edu/live/image/gid/7/74_KBH_Symposium.png");
+    ).toBe('https://calendar.mccombs.utexas.edu/live/image/gid/7/74_KBH_Symposium.png');
   });
 
-  it("is idempotent on URLs that are already original", () => {
-    const url = "https://calendar.mccombs.utexas.edu/live/image/gid/7/flyer.png";
+  it('is idempotent on URLs that are already original', () => {
+    const url = 'https://calendar.mccombs.utexas.edu/live/image/gid/7/flyer.png';
     expect(upgradeImageUrl(url)).toBe(url);
   });
 
-  it("returns null for missing input", () => {
+  it('returns null for missing input', () => {
     expect(upgradeImageUrl(null)).toBeNull();
   });
 });
 
-describe("extractRsvpUrl", () => {
-  it("finds a bare URL in the description", () => {
-    expect(extractRsvpUrl("Register at https://example.com/register.")).toBe(
-      "https://example.com/register",
+describe('extractRsvpUrl', () => {
+  it('finds a bare URL in the description', () => {
+    expect(extractRsvpUrl('Register at https://example.com/register.')).toBe(
+      'https://example.com/register',
     );
   });
 
   it("returns null when there's no URL", () => {
-    expect(extractRsvpUrl("RSVP required to attend.")).toBeNull();
+    expect(extractRsvpUrl('RSVP required to attend.')).toBeNull();
     expect(extractRsvpUrl(null)).toBeNull();
   });
 });
 
-describe("decodeHtmlEntities", () => {
-  it("decodes common entities", () => {
-    expect(decodeHtmlEntities("AT&amp;T &lt;tag&gt; &quot;quote&quot; &#39;s&#39;")).toBe(
+describe('decodeHtmlEntities', () => {
+  it('decodes common entities', () => {
+    expect(decodeHtmlEntities('AT&amp;T &lt;tag&gt; &quot;quote&quot; &#39;s&#39;')).toBe(
       `AT&T <tag> "quote" 's'`,
     );
   });
 });
 
-describe("extractLocs", () => {
-  it("extracts <loc> entries from sitemap XML", () => {
+describe('extractLocs', () => {
+  it('extracts <loc> entries from sitemap XML', () => {
     const xml = `<?xml version="1.0"?>
       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
         <url><loc>https://calendar.mccombs.utexas.edu/alumni/event/1-a</loc></url>
         <url><loc>https://calendar.mccombs.utexas.edu/gsli/event/2-b</loc></url>
       </urlset>`;
     expect(extractLocs(xml)).toEqual([
-      "https://calendar.mccombs.utexas.edu/alumni/event/1-a",
-      "https://calendar.mccombs.utexas.edu/gsli/event/2-b",
+      'https://calendar.mccombs.utexas.edu/alumni/event/1-a',
+      'https://calendar.mccombs.utexas.edu/gsli/event/2-b',
     ]);
   });
 
-  it("returns an empty array when there are no <loc> entries", () => {
-    expect(extractLocs("<urlset></urlset>")).toEqual([]);
+  it('returns an empty array when there are no <loc> entries', () => {
+    expect(extractLocs('<urlset></urlset>')).toEqual([]);
   });
 });
 
-describe("parseImageDimensions", () => {
-  it("reads width/height from a PNG header", () => {
-    // Minimal valid PNG header: signature + IHDR chunk declaring 600x400.
+describe('parseImageDimensions', () => {
+  it('reads width/height from a PNG header', () => {
     const bytes = new Uint8Array(24);
     bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
     const view = new DataView(bytes.buffer);
@@ -231,7 +232,7 @@ describe("parseImageDimensions", () => {
     expect(parseImageDimensions(bytes)).toEqual({ width: 600, height: 400 });
   });
 
-  it("reads width/height from a GIF header", () => {
+  it('reads width/height from a GIF header', () => {
     const bytes = new Uint8Array(10);
     bytes.set([0x47, 0x49, 0x46, 0x38, 0x39, 0x61], 0); // "GIF89a"
     const view = new DataView(bytes.buffer);
@@ -240,23 +241,30 @@ describe("parseImageDimensions", () => {
     expect(parseImageDimensions(bytes)).toEqual({ width: 320, height: 240 });
   });
 
-  it("reads width/height from a baseline JPEG SOF0 marker", () => {
-    // SOI, then a single SOF0 (0xFFC0) segment: length=17, precision=8,
-    // height=300, width=500, 1 component (minimal valid payload).
+  it('reads width/height from a baseline JPEG SOF0 marker', () => {
+    // SOI + single SOF0 (0xFFC0): length=17, precision=8, height=300,
+    // width=500, 1 component (minimal valid payload).
     const bytes = new Uint8Array([
-      0xff, 0xd8, // SOI
-      0xff, 0xc0, // SOF0
-      0x00, 0x11, // segment length = 17
+      0xff,
+      0xd8, // SOI
+      0xff,
+      0xc0, // SOF0
+      0x00,
+      0x11, // segment length = 17
       0x08, // precision
-      0x01, 0x2c, // height = 300
-      0x01, 0xf4, // width = 500
+      0x01,
+      0x2c, // height = 300
+      0x01,
+      0xf4, // width = 500
       0x01, // number of components
-      0x01, 0x22, 0x00, // component data
+      0x01,
+      0x22,
+      0x00, // component data
     ]);
     expect(parseImageDimensions(bytes)).toEqual({ width: 500, height: 300 });
   });
 
-  it("returns null for unrecognized data", () => {
+  it('returns null for unrecognized data', () => {
     expect(parseImageDimensions(new Uint8Array([1, 2, 3, 4]))).toBeNull();
   });
 });

--- a/server/src/scrapers/mccombs.ts
+++ b/server/src/scrapers/mccombs.ts
@@ -1,51 +1,34 @@
-/**
- * McCombs Events scraper — pulls events from calendar.mccombs.utexas.edu
- * (a LiveWhale Calendar instance) and upserts them into D1.
- *
- * LiveWhale doesn't expose a public JSON API the way Localist does (the
- * in-page calendar widget hydrates client-side via an undocumented AJAX
- * endpoint that requires an obfuscated "widget syntax" token we can't
- * reproduce server-side). Instead we use two things LiveWhale *does* render
- * server-side and that are stable/documented:
- *
- *  1. `/sitemap.livewhale.xml` -> `/sitemap.events.xml` — a standard XML
- *     sitemap listing every event page URL across all McCombs sub-calendars
- *     (Alumni, GSLI, McCombs+, BBA, MBA programs, etc). This is our
- *     discovery/pagination mechanism.
- *  2. Each event page embeds a schema.org `Event` JSON-LD block
- *     (`<script type="application/ld+json">`) for SEO. This is our data
- *     source — title, dates, location, organizer, and (when present) a
- *     flyer image.
- *
- * Caveats this approach inherits (documented rather than papered over):
- *  - `rsvp_url` is only populated when an event's description happens to
- *    contain a literal URL — LiveWhale doesn't expose registration links
- *    as structured data server-side.
- *  - `image_alt_text` is never available — not present in the JSON-LD.
- *  - Per-event tags/audience aren't exposed server-side either, so we don't
- *    write to `event_categories` for this source (see LOOP-147 discussion;
- *    the `events` table also has no `tags`/`audience` column to fill).
- *
- * Deduplication key: (source, source_event_id) = ("mccombs", numeric event ID
- * parsed out of the event URL, e.g. ".../event/11049-some-slug" -> "11049").
- */
+// McCombs scraper: calendar.mccombs.utexas.edu (LiveWhale).
+//
+// LiveWhale has no JSON API. We work around that with:
+//   1. The sitemap at /sitemap.livewhale.xml lists every event page URL.
+//   2. Each event page has a schema.org Event JSON-LD block for SEO,
+//      which we parse for the actual event data.
+//
+// Things we can't get:
+//   - rsvpUrl only appears if the organizer pasted a bare URL into the
+//     description. LiveWhale doesn't expose the registration link itself.
+//   - imageAltText is not in the JSON-LD.
+//   - Tags / audience are not server-rendered, so no event_categories rows.
+//
+// Dedup key: numeric event id from the URL (".../event/11049-slug" -> "11049").
 
-import type { Env } from "../worker";
+import { ingestEvents } from '../events/ingest';
+import { classifyAspectRatio, fetchImageMeta } from '../events/normalize';
+import { fetchWithRetry, sleep } from '../events/polite-fetch';
+import type { NormalizedEvent } from '../events/types';
+import type { Env } from '../worker';
 
-const SITEMAP_INDEX_URL =
-  "https://calendar.mccombs.utexas.edu/sitemap.livewhale.xml";
-const USER_AGENT = "LonghornLoop/1.0 (+https://longhornloop.app)";
-export const SOURCE = "mccombs";
+const SITEMAP_INDEX_URL = 'https://calendar.mccombs.utexas.edu/sitemap.livewhale.xml';
+export const SOURCE = 'mccombs';
 
-// Polite scraping settings — sequential fetches with a short delay between
-// event pages, plus a hard cap so a single cron run can't run away.
 const REQUEST_DELAY_MS = 200;
 const DEFAULT_MAX_EVENTS = 500;
+const DEFAULT_ORG_NAME = 'McCombs School of Business';
 
-// ─── JSON-LD shape (schema.org Event, as rendered by LiveWhale) ───────────
-
+// schema.org Event shape, as LiveWhale renders it
 interface LiveWhaleEventJsonLd {
-  "@type": string;
+  '@type': string;
   name: string;
   startDate: string;
   endDate?: string;
@@ -59,28 +42,6 @@ interface LiveWhaleEventJsonLd {
   image?: { url?: string; width?: number; height?: number };
 }
 
-// ─── Output type ──────────────────────────────────────────────────────────
-
-export interface ParsedEvent {
-  source: string;
-  source_event_id: string;
-  title: string;
-  description: string | null;
-  start_datetime: string;
-  end_datetime: string | null;
-  location_short: string | null;
-  location_full: string | null;
-  host_organization_name: string | null;
-  event_url: string;
-  rsvp_url: string | null;
-  image_url: string | null;
-  image_width: number | null;
-  image_height: number | null;
-  image_aspect_ratio: "vertical" | "square" | "horizontal" | "none";
-  image_mime_type: string | null;
-  image_alt_text: string | null;
-}
-
 interface ScraperResult {
   eventsProcessed: number;
   eventsUpserted: number;
@@ -89,223 +50,106 @@ interface ScraperResult {
   durationMs: number;
 }
 
-// ─── Pure helper functions (exported for unit tests) ──────────────────────
+// Helpers, exported for unit tests
 
-/** Decode the small set of HTML entities LiveWhale leaves in JSON-LD text. */
 export function decodeHtmlEntities(text: string): string {
   return text
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#0?39;/g, "'")
-    .replace(/&nbsp;/g, " ");
+    .replace(/&nbsp;/g, ' ');
 }
 
-/** Collapse the multi-space runs left behind when LiveWhale strips HTML tags. */
-export function cleanDescription(
-  description: string | null | undefined,
-): string | null {
+export function cleanDescription(description: string | null | undefined): string | null {
   if (!description) return null;
-  const cleaned = decodeHtmlEntities(description).replace(/\s+/g, " ").trim();
+  const cleaned = decodeHtmlEntities(description).replace(/\s+/g, ' ').trim();
   return cleaned || null;
 }
 
-/**
- * Find the first literal URL inside a description and treat it as the
- * registration / RSVP link. LiveWhale renders "Register now" as plain text
- * (the anchor's href is lost), so this only catches the case where an
- * organizer pastes a bare URL into the description body.
- */
-export function extractRsvpUrl(
-  description: string | null | undefined,
-): string | null {
+// LiveWhale flattens "Register now" links into plain text, so we can only
+// catch RSVP links when the organizer pasted a bare URL into the body.
+export function extractRsvpUrl(description: string | null | undefined): string | null {
   if (!description) return null;
   const match = decodeHtmlEntities(description).match(/https?:\/\/\S+/);
   if (!match) return null;
-  return match[0].replace(/[.,)\]]+$/, "");
+  return match[0].replace(/[.,)\]]+$/, '');
 }
 
-/**
- * Strip the "Org Name (McCombs School of Business - The University of Texas
- * at Austin)" boilerplate suffix LiveWhale appends to every organizer name,
- * leaving the specific department/center/program (e.g. "MSITM",
- * "Herb Kelleher Center").
- */
-export function cleanHostOrganization(
-  organizerName: string | null | undefined,
-): string | null {
+// Every organizer name has a "(McCombs School of Business - ...)"
+// suffix appended. Strip it so we get the specific unit.
+export function cleanHostOrganization(organizerName: string | null | undefined): string | null {
   if (!organizerName) return null;
   const decoded = decodeHtmlEntities(organizerName).trim();
-  const stripped = decoded.replace(/\s*\(McCombs School of Business[^)]*\)\s*$/i, "");
+  const stripped = decoded.replace(/\s*\(McCombs School of Business[^)]*\)\s*$/i, '');
   return stripped || decoded || null;
 }
 
-/**
- * Extract a stable dedup ID from an event URL. Most events get a numeric ID
- * LiveWhale embeds right after "/event/" (e.g. "/event/11049-some-slug" ->
- * "11049"). Some organizers opt into a vanity slug instead
- * (e.g. "/event/career-expo", with no number at all) — for those, fall
- * back to the full URL path, which is still unique and stable site-wide.
- */
-export function extractSourceEventId(eventUrl: string): string | null {
+// "/event/11049-slug" -> "11049". Vanity slugs (no number) fall back
+// to the URL path. Specific to LiveWhale URL structure.
+export function extractMccombsEventId(eventUrl: string): string | null {
   const numeric = eventUrl.match(/\/event\/(\d+)/);
   if (numeric) return numeric[1];
 
   try {
-    const path = new URL(eventUrl).pathname.replace(/^\/+|\/+$/g, "");
+    const path = new URL(eventUrl).pathname.replace(/^\/+|\/+$/g, '');
     return path || null;
   } catch {
     return null;
   }
 }
 
-/**
- * Build a display-friendly short location (≤ 40 chars). LiveWhale gives us
- * one combined "venue, street address" string — we take the part before the
- * first comma as the venue name when there is one.
- */
-export function buildLocationShort(
-  location: string | null | undefined,
-): string | null {
+// LiveWhale gives one "venue, street address" string. Take the part
+// before the first comma as the venue.
+export function buildLocationShort(location: string | null | undefined): string | null {
   if (!location) return null;
   const decoded = decodeHtmlEntities(location).trim();
-  const firstSegment = decoded.split(",")[0].trim();
+  const firstSegment = decoded.split(',')[0].trim();
   const candidate = firstSegment || decoded;
   if (candidate.length <= 40) return candidate;
-  return candidate.substring(0, 37) + "...";
+  return candidate.substring(0, 37) + '...';
 }
 
-export function buildLocationFull(
-  location: string | null | undefined,
-): string | null {
+export function buildLocationFull(location: string | null | undefined): string | null {
   if (!location) return null;
   const decoded = decodeHtmlEntities(location).trim();
   return decoded || null;
 }
 
-/**
- * Classify the aspect ratio of an image. Uses a 5% tolerance band so a
- * 1000×999 image reads as "square" not "horizontal". Returns "none" when
- * dimensions are absent (no image).
- */
-export function classifyAspectRatio(
-  width: number | null | undefined,
-  height: number | null | undefined,
-): "vertical" | "square" | "horizontal" | "none" {
-  if (!width || !height || width <= 0 || height <= 0) return "none";
-  const ratio = width / height;
-  if (ratio > 1.05) return "horizontal";
-  if (ratio < 0.95) return "vertical";
-  return "square";
-}
-
-/**
- * LiveWhale serves resized/cropped variants at URLs like
- * `/live/image/gid/{id}/width/600/height/600/crop/1/src_region/.../file.png`.
- * Stripping the width/height/crop/src_region segment returns the original
- * full-resolution upload at `/live/image/gid/{id}/file.png`.
- */
+// LiveWhale serves resized images at .../live/image/gid/{id}/width/N/height/N/crop/1/src_region/.../file.
+// Strip that segment to get the original upload URL. LiveWhale-specific.
 export function upgradeImageUrl(url: string | null | undefined): string | null {
   if (!url) return null;
-  return url.replace(/\/width\/\d+\/height\/\d+\/crop\/\d+\/src_region\/[^/]+/, "");
+  return url.replace(/\/width\/\d+\/height\/\d+\/crop\/\d+\/src_region\/[^/]+/, '');
 }
 
-/**
- * Parse width/height out of raw image bytes (PNG, JPEG, or GIF headers).
- * Returns null when the format isn't recognized or there aren't enough
- * bytes to read the header — callers should treat that as "unknown",
- * not an error.
- */
-export function parseImageDimensions(
-  bytes: Uint8Array,
-): { width: number; height: number } | null {
-  // PNG: 8-byte signature, then an IHDR chunk with width/height as
-  // big-endian uint32s at offsets 16 and 20.
-  if (
-    bytes.length >= 24 &&
-    bytes[0] === 0x89 &&
-    bytes[1] === 0x50 &&
-    bytes[2] === 0x4e &&
-    bytes[3] === 0x47
-  ) {
-    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-    return { width: view.getUint32(16), height: view.getUint32(20) };
-  }
-
-  // GIF: 6-byte signature, then width/height as little-endian uint16s.
-  if (
-    bytes.length >= 10 &&
-    bytes[0] === 0x47 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46
-  ) {
-    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-    return { width: view.getUint16(6, true), height: view.getUint16(8, true) };
-  }
-
-  // JPEG: walk the marker segments looking for a Start-Of-Frame marker
-  // (0xC0–0xCF, excluding the DHT/JPG markers 0xC4, 0xC8, 0xCC).
-  if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) {
-    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-    let offset = 2;
-    while (offset + 9 < bytes.length) {
-      if (bytes[offset] !== 0xff) {
-        offset++;
-        continue;
-      }
-      const marker = bytes[offset + 1];
-      if (marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc) {
-        return {
-          height: view.getUint16(offset + 5),
-          width: view.getUint16(offset + 7),
-        };
-      }
-      const segmentLength = view.getUint16(offset + 2);
-      offset += 2 + segmentLength;
-    }
-  }
-
-  return null;
-}
-
-// ─── XML sitemap parsing (regex-based — sitemaps are simple, well-formed) ─
-
+// Sitemaps are simple and well-formed, so a regex works fine.
 export function extractLocs(xml: string): string[] {
   return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1].trim());
 }
 
-// ─── JSON-LD extraction + event parsing ────────────────────────────────────
-
 function extractEventJsonLd(html: string): LiveWhaleEventJsonLd | null {
-  const blocks = html.matchAll(
-    /<script type="application\/ld\+json">([\s\S]*?)<\/script>/g,
-  );
+  const blocks = html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g);
   for (const block of blocks) {
     const raw = block[1]
-      .replace(/\/\*<!\[CDATA\[\*\//, "")
-      .replace(/\/\*\]\]>\*\//, "")
+      .replace(/\/\*<!\[CDATA\[\*\//, '')
+      .replace(/\/\*\]\]>\*\//, '')
       .trim();
     try {
       const parsed = JSON.parse(raw);
-      if (parsed && parsed["@type"] === "Event") return parsed;
+      if (parsed && parsed['@type'] === 'Event') return parsed;
     } catch {
-      // Not valid JSON (or not the block we want) — keep looking.
+      // Not the block we want. Keep looking.
     }
   }
   return null;
 }
 
-/**
- * Parse one event detail page into our normalized shape. Pure/sync so it
- * can be unit-tested directly against saved HTML fixtures — image
- * width/height/mime are filled in afterward by the orchestrator, which
- * needs a network round trip the parser itself shouldn't make.
- */
-export function parseEventFromHtml(
-  html: string,
-  pageUrl: string,
-): ParsedEvent | null {
+// Pure and sync so it's easy to test against saved HTML fixtures.
+// The orchestrator fills in image width/height/mime after this runs,
+// since those need a network round-trip that doesn't belong in a parser.
+export function parseEventFromHtml(html: string, pageUrl: string): NormalizedEvent | null {
   const event = extractEventJsonLd(html);
   if (!event) {
     console.warn(`[mccombs] No Event JSON-LD found on ${pageUrl} — skipping`);
@@ -313,7 +157,7 @@ export function parseEventFromHtml(
   }
 
   const eventUrl = event.url || pageUrl;
-  const sourceEventId = extractSourceEventId(eventUrl);
+  const sourceEventId = extractMccombsEventId(eventUrl);
   if (!sourceEventId) {
     console.warn(`[mccombs] Could not extract event ID from ${eventUrl} — skipping`);
     return null;
@@ -328,164 +172,55 @@ export function parseEventFromHtml(
   const locationString = place?.address?.streetAddress || place?.name || null;
   const description = cleanDescription(event.description);
   const imageUrl = upgradeImageUrl(event.image?.url);
+  const orgName = cleanHostOrganization(event.organizer?.name) ?? DEFAULT_ORG_NAME;
 
   return {
     source: SOURCE,
-    source_event_id: sourceEventId,
-    title: decodeHtmlEntities(event.name || "").trim(),
+    sourceEventId,
+    title: decodeHtmlEntities(event.name || '').trim(),
     description,
-    start_datetime: event.startDate,
-    end_datetime: event.endDate ?? null,
-    location_short: buildLocationShort(locationString),
-    location_full: buildLocationFull(locationString),
-    host_organization_name: cleanHostOrganization(event.organizer?.name),
-    event_url: eventUrl,
-    rsvp_url: extractRsvpUrl(description),
-    image_url: imageUrl,
-    // Filled in by fetchImageMeta() in the orchestrator when image_url is set.
-    image_width: null,
-    image_height: null,
-    image_aspect_ratio: imageUrl ? "horizontal" : "none",
-    image_mime_type: null,
-    image_alt_text: null,
+    startDatetime: event.startDate,
+    endDatetime: event.endDate ?? null,
+    locationShort: buildLocationShort(locationString),
+    locationFull: buildLocationFull(locationString),
+    latitude: null,
+    longitude: null,
+    organization: {
+      // Departments have no numeric id, so ingest skips the org row.
+      sourceOrgId: null,
+      name: orgName,
+      profilePicture: null,
+    },
+    eventUrl,
+    rsvpUrl: extractRsvpUrl(description),
+    imageUrl,
+    // fetchImageMeta() fills these in later when imageUrl is set.
+    imageWidth: null,
+    imageHeight: null,
+    imageAspectRatio: imageUrl ? 'horizontal' : 'none',
+    imageMimeType: null,
+    imageAltText: null,
+    theme: null,
+    visibility: 'Public',
+    rsvpTotal: 0,
+    categories: [],
+    benefits: [],
   };
 }
 
-// ─── Fetchers ───────────────────────────────────────────────────────────
-
-async function fetchText(url: string): Promise<string> {
-  const res = await fetch(url, {
-    headers: { "User-Agent": USER_AGENT, Accept: "*/*" },
-  });
-  if (!res.ok) {
-    throw new Error(`${res.status} ${res.statusText} — ${url}`);
-  }
-  return res.text();
-}
-
-/** Discover every event page URL via the LiveWhale sitemap. */
 export async function discoverEventUrls(): Promise<string[]> {
-  const indexXml = await fetchText(SITEMAP_INDEX_URL);
+  const indexRes = await fetchWithRetry(SITEMAP_INDEX_URL, { headers: { Accept: '*/*' } });
+  const indexXml = await indexRes.text();
   const sitemapUrls = extractLocs(indexXml);
 
   const eventUrls = new Set<string>();
   for (const sitemapUrl of sitemapUrls) {
-    const xml = await fetchText(sitemapUrl);
+    const res = await fetchWithRetry(sitemapUrl, { headers: { Accept: '*/*' } });
+    const xml = await res.text();
     for (const loc of extractLocs(xml)) eventUrls.add(loc);
   }
   return [...eventUrls];
 }
-
-/**
- * Fetch just enough of an image to read its header (width/height) and its
- * Content-Type, without downloading the whole (possibly multi-MB) file.
- */
-async function fetchImageMeta(
-  imageUrl: string,
-): Promise<{ width: number | null; height: number | null; mimeType: string | null }> {
-  try {
-    const res = await fetch(imageUrl, {
-      headers: { "User-Agent": USER_AGENT, Range: "bytes=0-65535" },
-    });
-    if (!res.ok && res.status !== 206) {
-      return { width: null, height: null, mimeType: null };
-    }
-    const mimeType = res.headers.get("content-type");
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    const dims = parseImageDimensions(bytes);
-    return { width: dims?.width ?? null, height: dims?.height ?? null, mimeType };
-  } catch (err) {
-    console.warn(`[mccombs] Failed to read image metadata for ${imageUrl}: ${err}`);
-    return { width: null, height: null, mimeType: null };
-  }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-// ─── D1 upsert ────────────────────────────────────────────────────────────
-
-const UPSERT_SQL = `
-  INSERT INTO events (
-    source, source_event_id, title, description,
-    start_datetime, end_datetime,
-    location_short, location_full,
-    host_organization_id, host_organization_name,
-    event_url, rsvp_url,
-    image_url, image_width, image_height, image_aspect_ratio,
-    image_mime_type, image_alt_text,
-    expires_at,
-    visibility, status, updated_at
-  ) VALUES (
-    ?, ?, ?, ?,
-    ?, ?,
-    ?, ?,
-    NULL, ?,
-    ?, ?,
-    ?, ?, ?, ?,
-    ?, ?,
-    ?,
-    'Public', 'active', datetime('now')
-  )
-  ON CONFLICT(source, source_event_id) DO UPDATE SET
-    title                  = excluded.title,
-    description            = excluded.description,
-    start_datetime         = excluded.start_datetime,
-    end_datetime           = excluded.end_datetime,
-    location_short         = excluded.location_short,
-    location_full          = excluded.location_full,
-    host_organization_name = excluded.host_organization_name,
-    event_url              = excluded.event_url,
-    rsvp_url               = excluded.rsvp_url,
-    image_url              = excluded.image_url,
-    image_width            = excluded.image_width,
-    image_height           = excluded.image_height,
-    image_aspect_ratio     = excluded.image_aspect_ratio,
-    image_mime_type        = excluded.image_mime_type,
-    image_alt_text         = excluded.image_alt_text,
-    expires_at              = excluded.expires_at,
-    updated_at              = datetime('now')
-`;
-
-// Purge target for the cleanup job (LOOP-150): end time + 7 days, falling
-// back to the start time when an event has no end time.
-const EXPIRES_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
-
-function computeExpiresAt(endDatetime: string | null, startDatetime: string): string {
-  const base = endDatetime ?? startDatetime;
-  return new Date(new Date(base).getTime() + EXPIRES_AFTER_MS).toISOString();
-}
-
-async function upsertEvent(db: D1Database, e: ParsedEvent): Promise<void> {
-  const expiresAt = computeExpiresAt(e.end_datetime, e.start_datetime);
-
-  await db
-    .prepare(UPSERT_SQL)
-    .bind(
-      e.source,
-      e.source_event_id,
-      e.title,
-      e.description,
-      e.start_datetime,
-      e.end_datetime,
-      e.location_short,
-      e.location_full,
-      e.host_organization_name,
-      e.event_url,
-      e.rsvp_url,
-      e.image_url,
-      e.image_width,
-      e.image_height,
-      e.image_aspect_ratio,
-      e.image_mime_type,
-      e.image_alt_text,
-      expiresAt,
-    )
-    .run();
-}
-
-// ─── Orchestrator ─────────────────────────────────────────────────────────
 
 export async function scrapeMccombs(
   db: D1Database,
@@ -506,40 +241,49 @@ export async function scrapeMccombs(
   } catch (err) {
     const msg = `Fatal error discovering event URLs: ${err}`;
     console.error(`[mccombs] ${msg}`);
-    return { eventsProcessed: 0, eventsUpserted: 0, eventsSkipped: 0, errors: [msg], durationMs: Date.now() - t0 };
+    return {
+      eventsProcessed: 0,
+      eventsUpserted: 0,
+      eventsSkipped: 0,
+      errors: [msg],
+      durationMs: Date.now() - t0,
+    };
   }
 
   console.log(`[mccombs] Discovered ${eventUrls.length} event URLs`);
 
+  const normalized: NormalizedEvent[] = [];
+
   for (const url of eventUrls.slice(0, maxEvents)) {
     eventsProcessed++;
     try {
-      const html = await fetchText(url);
+      const res = await fetchWithRetry(url, { headers: { Accept: '*/*' } });
+      const html = await res.text();
       const parsed = parseEventFromHtml(html, url);
       if (!parsed) {
         eventsSkipped++;
         continue;
       }
 
-      if (parsed.image_url) {
-        const meta = await fetchImageMeta(parsed.image_url);
-        parsed.image_width = meta.width;
-        parsed.image_height = meta.height;
-        parsed.image_mime_type = meta.mimeType;
-        // Only override the "horizontal" default once we actually know the
-        // real dimensions — an unreadable header keeps the safe default.
+      if (parsed.imageUrl) {
+        const meta = await fetchImageMeta(parsed.imageUrl, 'mccombs');
+        parsed.imageWidth = meta.width;
+        parsed.imageHeight = meta.height;
+        parsed.imageMimeType = meta.mimeType;
+        // Only override the "horizontal" default when we actually know the
+        // dimensions. An unreadable header keeps the safe fallback.
+        // Tighter 5% tolerance since dimensions came from the real header.
         if (meta.width && meta.height) {
-          parsed.image_aspect_ratio = classifyAspectRatio(meta.width, meta.height);
+          parsed.imageAspectRatio = classifyAspectRatio(meta.width, meta.height, true, 0.05);
         }
       }
 
       if (dryRun) {
         console.log(
-          `[DRY RUN] Event: ${parsed.title} (${parsed.source_event_id}) — ${parsed.host_organization_name ?? "no org"}`,
+          `[DRY RUN] "${parsed.title}" (${parsed.sourceEventId}) — ${parsed.organization.name}`,
         );
       } else {
-        await upsertEvent(db, parsed);
-        eventsUpserted++;
+        normalized.push(parsed);
       }
     } catch (err) {
       const msg = `Failed to process ${url}: ${err}`;
@@ -550,6 +294,12 @@ export async function scrapeMccombs(
     await sleep(REQUEST_DELAY_MS);
   }
 
+  if (!dryRun && normalized.length > 0) {
+    const result = await ingestEvents(db, normalized);
+    eventsUpserted = result.inserted + result.updated;
+    errors.push(...result.errors);
+  }
+
   const durationMs = Date.now() - t0;
   console.log(
     `[mccombs] Finished in ${(durationMs / 1000).toFixed(1)}s — ${eventsUpserted} upserted, ${eventsSkipped} skipped, ${errors.length} errors`,
@@ -558,8 +308,7 @@ export async function scrapeMccombs(
   return { eventsProcessed, eventsUpserted, eventsSkipped, errors, durationMs };
 }
 
-/** Called by the scheduled cron handler in worker.ts. */
 export async function run(env: Env): Promise<void> {
-  console.log("[mccombs] Scraper started");
+  console.log('[mccombs] Scraper started');
   await scrapeMccombs(env.DB);
 }

--- a/server/src/scrapers/registry.ts
+++ b/server/src/scrapers/registry.ts
@@ -1,0 +1,22 @@
+// Central list of every scraper. worker.ts iterates this list on the
+// scrape cron; adding a new scraper is one line here plus a new file.
+//
+// Each entry is:
+//   name: short id for logs / metrics
+//   run:  the (env) => Promise<void> cron entrypoint
+
+import { run as runHornsLink } from './hornslink';
+import { run as runMccombs } from './mccombs';
+import { run as runTexasToday } from './texasToday';
+import type { Env } from '../worker';
+
+export interface ScraperEntry {
+  name: string;
+  run: (env: Env) => Promise<void>;
+}
+
+export const SCRAPERS: ScraperEntry[] = [
+  { name: 'hornslink', run: runHornsLink },
+  { name: 'texasToday', run: runTexasToday },
+  { name: 'mccombs', run: runMccombs },
+];

--- a/server/src/scrapers/texasToday.ts
+++ b/server/src/scrapers/texasToday.ts
@@ -1,31 +1,26 @@
-/**
- * Texas Today scraper — pulls events from calendar.utexas.edu (Localist JSON API)
- * and upserts them into D1.
- *
- * The UT Austin calendar runs on Localist, which exposes a JSON API at
- * /api/2/events. We prefer this over HTML scraping because it's stable,
- * paginated, and returns structured data including image dimensions.
- *
- * Deduplication key: (source, source_event_id) = ("texas_today", instance_id)
- * Using the instance ID (not event ID) means recurring events produce one row
- * per occurrence — the home feed can then show each date as a separate card.
- */
+// Texas Today scraper: calendar.utexas.edu (Localist JSON API).
+// Dedup key: instance_id, not event_id, so recurring events get one row
+// per occurrence.
 
+import { ingestEvents } from '../events/ingest';
+import { classifyAspectRatio, stripHtml } from '../events/normalize';
+import { fetchWithRetry } from '../events/polite-fetch';
+import type { ImageAspectRatio, NormalizedEvent } from '../events/types';
 import type { Env } from '../worker';
 
 const BASE_URL = 'https://calendar.utexas.edu';
 const API_BASE = `${BASE_URL}/api/2/events`;
 const PER_PAGE = 100;
-const DAYS_AHEAD = 365;
+const DAYS_AHEAD = 30;
 export const SOURCE = 'texas_today';
 
-// ─── Localist API types ────────────────────────────────────────────────────
+// Localist API types
 
 interface LocalistEventInstance {
   event_instance: {
     id: number;
     event_id: number;
-    start: string; // ISO 8601 with America/Chicago offset, e.g. "2024-02-28T16:00:00-06:00"
+    start: string; // ISO 8601 with America/Chicago offset
     end: string | null;
     all_day: boolean;
   };
@@ -70,80 +65,16 @@ interface LocalistApiResponse {
   };
 }
 
-// ─── Output type ──────────────────────────────────────────────────────────
-
-export interface ParsedEvent {
-  source: string;
-  source_event_id: string;
-  title: string;
-  description: string | null;
-  start_datetime: string;
-  end_datetime: string | null;
-  location_short: string | null;
-  location_full: string | null;
-  // Matches the events table column name (host_organization_name).
-  // host_organization_id is always null for Texas Today (no numeric org IDs).
-  host_organization_name: string | null;
-  event_url: string;
-  image_url: string | null;
-  image_width: number | null;
-  image_height: number | null;
-  image_aspect_ratio: 'vertical' | 'square' | 'horizontal' | 'none';
-  image_mime_type: string | null;
-  image_alt_text: string | null;
-  // Not stored in the events row — written to event_categories after upsert.
-  categories: Array<{ id: string; name: string }>;
-}
-
-// ─── Pure helper functions (exported for unit tests) ──────────────────────
-
-/** Strip HTML tags and decode common entities to plain text. */
-export function stripHtml(html: string | null | undefined): string | null {
-  if (!html) return null;
-  const text = html
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/\s+/g, ' ')
-    .trim();
-  return text || null;
-}
-
-/**
- * Classify the aspect ratio of an image.
- * Uses a 5% tolerance band so a 1000×999 image reads as "square" not "horizontal".
- * Returns "none" when dimensions are absent (no image).
- */
-export function classifyAspectRatio(
-  width: number | null | undefined,
-  height: number | null | undefined,
-): 'vertical' | 'square' | 'horizontal' | 'none' {
-  if (!width || !height || width <= 0 || height <= 0) return 'none';
-  const ratio = width / height;
-  if (ratio > 1.05) return 'horizontal';
-  if (ratio < 0.95) return 'vertical';
-  return 'square';
-}
-
-/**
- * Build a display-friendly short location (≤ 40 chars).
- * We strip the street address portion (digits at word boundary) so that
- * "Gregory Gym (GRE), 2101 Speedway" becomes "Gregory Gym (GRE)".
- */
+// Strips trailing street address so "Gregory Gym (GRE), 2101 Speedway"
+// becomes "Gregory Gym (GRE)".
 export function buildLocationShort(location: string | null | undefined): string | null {
   if (!location) return null;
-  // Remove trailing address: ", 123 Something St"
   const stripped = location.replace(/,\s*\d+[^,]*$/, '').trim();
   const candidate = stripped || location.trim();
   if (candidate.length <= 40) return candidate;
   return candidate.substring(0, 37) + '...';
 }
 
-/** Combine venue name + street address into a full location string. */
 export function buildLocationFull(
   location: string | null | undefined,
   address: string | null | undefined,
@@ -152,11 +83,8 @@ export function buildLocationFull(
   return parts.length > 0 ? parts.join(', ') : null;
 }
 
-/**
- * Try to upgrade a Localist CDN thumbnail URL to the highest resolution.
- * Localist stores images at path segments like /thumb/, /medium/, /small/.
- * Replacing with /huge/ gets the original upload.
- */
+// Localist serves images at /thumb/, /medium/, /small/, /huge/.
+// /huge/ is the original upload.
 export function upgradeImageUrl(url: string | null | undefined): string | null {
   if (!url) return null;
   return url
@@ -165,25 +93,11 @@ export function upgradeImageUrl(url: string | null | undefined): string | null {
     .replace(/\/small\//, '/huge/');
 }
 
-/** Derive a slug for a department from its hashtag or URL path. */
-export function extractDepartmentSlug(dept: LocalistDepartment): string {
-  if (dept.hashtag) return dept.hashtag;
-  const url = dept.localist_url || dept.url;
-  if (!url) return dept.name.toLowerCase().replace(/\s+/g, '-');
-  const match = url.match(/\/([^/]+)\/?$/);
-  return match ? match[1] : dept.name.toLowerCase().replace(/\s+/g, '-');
-}
-
-// ─── Parser ───────────────────────────────────────────────────────────────
-
-/**
- * Parse one Localist event + one of its instances into our normalized shape.
- * Returns null (with a warning log) when required fields are missing.
- */
+// Returns null when required fields are missing.
 export function parseEventInstance(
   raw: LocalistRawEvent,
   instance: LocalistEventInstance,
-): ParsedEvent | null {
+): NormalizedEvent | null {
   const e = raw.event;
   const inst = instance.event_instance;
 
@@ -192,11 +106,14 @@ export function parseEventInstance(
     return null;
   }
 
+  // First department is what the event submitter chose in the Localist UI.
+  // Usually the school or office that owns the event (e.g. "McCombs School
+  // of Business"). We only take the first; extras are rare on this feed.
   const dept = e.departments?.[0] ?? null;
 
-  // Merge event-level tags + event_type filter labels into categories
+  // Categories combine free-form tags with the event_type filter labels.
   const seen = new Set<string>();
-  const categories: Array<{ id: string; name: string }> = [];
+  const categories: Array<{ id: string; name: string | null }> = [];
   for (const tag of [...(e.tags ?? []), ...(e.filters?.event_types?.map((t) => t.name) ?? [])]) {
     if (tag && !seen.has(tag)) {
       seen.add(tag);
@@ -207,51 +124,62 @@ export function parseEventInstance(
   const imageUrl = upgradeImageUrl(e.photo_url);
   const hasImage = Boolean(imageUrl);
 
+  // Localist sometimes omits width/height. Fall back to "horizontal"
+  // since most flyers are landscape.
+  let aspect: ImageAspectRatio = 'none';
+  if (hasImage) {
+    const classified = classifyAspectRatio(e.photo_width, e.photo_height, true);
+    aspect = classified === 'square' && !e.photo_width ? 'horizontal' : classified;
+  }
+
   return {
     source: SOURCE,
-    // Use the instance ID so recurring events each get their own row
-    source_event_id: String(inst.id),
+    sourceEventId: String(inst.id),
     title: e.title,
     description: stripHtml(e.description),
-    start_datetime: inst.start,
-    end_datetime: inst.end ?? null,
-    location_short: buildLocationShort(e.location),
-    location_full: buildLocationFull(e.location, e.address),
-    host_organization_name: dept?.name ?? null,
-    event_url: e.localist_url || e.url,
-    image_url: imageUrl,
-    image_width: hasImage ? (e.photo_width ?? null) : null,
-    image_height: hasImage ? (e.photo_height ?? null) : null,
-    // The UT Localist API doesn't return photo_width/photo_height, so we
-    // default to "horizontal" (most event flyers are landscape) when we have
-    // an image but no dimension data. "none" is reserved for no-image events.
-    image_aspect_ratio: hasImage
-      ? classifyAspectRatio(e.photo_width, e.photo_height) === 'none'
-        ? 'horizontal'
-        : classifyAspectRatio(e.photo_width, e.photo_height)
-      : 'none',
-    image_mime_type: hasImage ? (e.photo_content_type ?? null) : null,
-    image_alt_text: hasImage ? (e.photo_alt ?? null) : null,
+    startDatetime: inst.start,
+    endDatetime: inst.end ?? null,
+    // Fall back to the street address when Localist has no named venue.
+    // Research studies and off-campus events often lack e.location.
+    locationShort: buildLocationShort(e.location || e.address),
+    locationFull: buildLocationFull(e.location, e.address),
+    latitude: null,
+    longitude: null,
+    organization: {
+      // Departments have no numeric id, so ingest skips the org row.
+      sourceOrgId: null,
+      name: dept?.name ?? 'The University of Texas at Austin',
+      profilePicture: null,
+    },
+    eventUrl: e.localist_url || e.url,
+    rsvpUrl: null,
+    imageUrl,
+    imageAspectRatio: aspect,
+    imageWidth: hasImage ? (e.photo_width ?? null) : null,
+    imageHeight: hasImage ? (e.photo_height ?? null) : null,
+    imageMimeType: hasImage ? (e.photo_content_type ?? null) : null,
+    imageAltText: hasImage ? (e.photo_alt ?? null) : null,
+    theme: null,
+    visibility: 'Public',
+    rsvpTotal: 0,
     categories,
+    benefits: [],
   };
 }
 
-/**
- * Convert a raw Localist event (which may have multiple instances) into one
- * ParsedEvent per upcoming instance.  We only keep instances whose start time
- * is in the future so we don't backfill stale rows on every run.
- */
-export function parseEvent(raw: LocalistRawEvent, now = Date.now()): ParsedEvent[] {
+// One raw event has N instances (recurrences). Emit one NormalizedEvent
+// per future instance.
+export function parseEvent(raw: LocalistRawEvent, now = Date.now()): NormalizedEvent[] {
   const instances = raw.event?.event_instances ?? [];
   if (instances.length === 0) {
     console.warn(`[texasToday] Event ${raw.event?.id} has no instances — skipping`);
     return [];
   }
 
-  const results: ParsedEvent[] = [];
+  const results: NormalizedEvent[] = [];
   for (const inst of instances) {
     const startMs = new Date(inst.event_instance.start).getTime();
-    if (isNaN(startMs) || startMs < now) continue; // skip past instances
+    if (isNaN(startMs) || startMs < now) continue;
 
     try {
       const parsed = parseEventInstance(raw, inst);
@@ -265,39 +193,28 @@ export function parseEvent(raw: LocalistRawEvent, now = Date.now()): ParsedEvent
   return results;
 }
 
-// ─── Fetcher ──────────────────────────────────────────────────────────────
-
 async function fetchPage(page: number): Promise<LocalistApiResponse> {
   const url = `${API_BASE}?days=${DAYS_AHEAD}&per_page=${PER_PAGE}&page=${page}`;
-  const res = await fetch(url, {
-    headers: {
-      Accept: 'application/json',
-      'User-Agent': 'LonghornLoop/1.0 (+https://longhornloop.app)',
-    },
-  });
-  if (!res.ok) {
-    throw new Error(`Localist API ${res.status} ${res.statusText} — ${url}`);
-  }
+  const res = await fetchWithRetry(url);
   return res.json() as Promise<LocalistApiResponse>;
 }
 
-export async function fetchAllEvents(): Promise<ParsedEvent[]> {
-  const parsed: ParsedEvent[] = [];
+export async function fetchAllEvents(): Promise<NormalizedEvent[]> {
+  const parsed: NormalizedEvent[] = [];
   let page = 1;
   let totalPages = 1;
   const now = Date.now();
 
   do {
-    console.log(`[texasToday] Fetching page ${page}/${totalPages} …`);
+    console.log(`[texasToday] Fetching page ${page}/${totalPages}...`);
     const data = await fetchPage(page);
 
-    // `page.total` is total number of pages (Localist quirk)
+    // Localist quirk: page.total is total number of pages, not events.
     totalPages = data.page.total;
 
     for (const rawEvent of data.events) {
       try {
-        const events = parseEvent(rawEvent, now);
-        parsed.push(...events);
+        parsed.push(...parseEvent(rawEvent, now));
       } catch (err) {
         console.error(`[texasToday] Unhandled parse error for event ${rawEvent.event?.id}: ${err}`);
       }
@@ -309,131 +226,12 @@ export async function fetchAllEvents(): Promise<ParsedEvent[]> {
   return parsed;
 }
 
-// ─── D1 upsert ────────────────────────────────────────────────────────────
-
-const UPSERT_SQL = `
-  INSERT INTO events (
-    source, source_event_id, title, description,
-    start_datetime, end_datetime,
-    location_short, location_full,
-    host_organization_id, host_organization_name,
-    event_url,
-    image_url, image_width, image_height, image_aspect_ratio,
-    image_mime_type, image_alt_text,
-    expires_at,
-    visibility, status, updated_at
-  ) VALUES (
-    ?, ?, ?, ?,
-    ?, ?,
-    ?, ?,
-    NULL, ?,
-    ?,
-    ?, ?, ?, ?,
-    ?, ?,
-    ?,
-    'Public', 'active', datetime('now')
-  )
-  ON CONFLICT(source, source_event_id) DO UPDATE SET
-    title                  = excluded.title,
-    description            = excluded.description,
-    start_datetime         = excluded.start_datetime,
-    end_datetime           = excluded.end_datetime,
-    location_short         = excluded.location_short,
-    location_full          = excluded.location_full,
-    host_organization_name = excluded.host_organization_name,
-    event_url              = excluded.event_url,
-    image_url              = excluded.image_url,
-    image_width            = excluded.image_width,
-    image_height           = excluded.image_height,
-    image_aspect_ratio     = excluded.image_aspect_ratio,
-    image_mime_type        = excluded.image_mime_type,
-    image_alt_text         = excluded.image_alt_text,
-    expires_at             = excluded.expires_at,
-    updated_at             = datetime('now')
-`;
-
-// Purge target for the cleanup job (LOOP-150): end time + 7 days, falling
-// back to the start time when an event has no end time.
-const EXPIRES_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
-
-function computeExpiresAt(endDatetime: string | null, startDatetime: string): string {
-  const base = endDatetime ?? startDatetime;
-  return new Date(new Date(base).getTime() + EXPIRES_AFTER_MS).toISOString();
-}
-
-async function upsertEvent(db: D1Database, e: ParsedEvent): Promise<void> {
-  const expiresAt = computeExpiresAt(e.end_datetime, e.start_datetime);
-
-  // Upsert the event row and get back the row ID (works for both insert + update)
-  const result = await db
-    .prepare(UPSERT_SQL)
-    .bind(
-      e.source,
-      e.source_event_id,
-      e.title,
-      e.description,
-      e.start_datetime,
-      e.end_datetime,
-      e.location_short,
-      e.location_full,
-      e.host_organization_name,
-      e.event_url,
-      e.image_url,
-      e.image_width,
-      e.image_height,
-      e.image_aspect_ratio,
-      e.image_mime_type,
-      e.image_alt_text,
-      expiresAt,
-    )
-    .run();
-
-  const eventId = result.meta.last_row_id;
-
-  if (e.categories.length > 0) {
-    // Replace categories: clear old ones then insert fresh set
-    await db.prepare('DELETE FROM event_categories WHERE event_id = ?').bind(eventId).run();
-
-    for (const cat of e.categories) {
-      await db
-        .prepare(
-          `INSERT OR IGNORE INTO event_categories (event_id, category_id, category_name)
-         VALUES (?, ?, ?)`,
-        )
-        .bind(eventId, cat.id, cat.name)
-        .run();
-    }
-  }
-}
-
-async function upsertEvents(
-  db: D1Database,
-  events: ParsedEvent[],
-): Promise<{ upserted: number; errors: number }> {
-  let upserted = 0;
-  let errors = 0;
-
-  for (const e of events) {
-    try {
-      await upsertEvent(db, e);
-      upserted++;
-    } catch (err) {
-      console.error(`[texasToday] Failed to upsert event instance ${e.source_event_id}: ${err}`);
-      errors++;
-    }
-  }
-
-  return { upserted, errors };
-}
-
-// ─── Public entrypoint ────────────────────────────────────────────────────
-
-/** Called by the scheduled cron handler in worker.ts. */
+// Cron entrypoint.
 export async function run(env: Env): Promise<void> {
   console.log('[texasToday] Scraper started');
   const t0 = Date.now();
 
-  let events: ParsedEvent[];
+  let events: NormalizedEvent[];
   try {
     events = await fetchAllEvents();
   } catch (err) {
@@ -443,8 +241,10 @@ export async function run(env: Env): Promise<void> {
 
   console.log(`[texasToday] Parsed ${events.length} event instances`);
 
-  const { upserted, errors } = await upsertEvents(env.DB, events);
+  const { inserted, updated, errors } = await ingestEvents(env.DB, events);
   const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
 
-  console.log(`[texasToday] Finished in ${elapsed}s — ${upserted} upserted, ${errors} errors`);
+  console.log(
+    `[texasToday] Finished in ${elapsed}s — ${inserted} inserted, ${updated} updated, ${errors.length} errors`,
+  );
 }

--- a/server/src/worker.ts
+++ b/server/src/worker.ts
@@ -6,9 +6,7 @@ import { eventRoutes } from './routes/events.worker';
 import { notificationRoutes } from './routes/notifications.worker';
 import { savedRoutes } from './routes/saved.worker';
 import { userRoutes } from './routes/users.worker';
-// import { run as runTexasToday } from "./scrapers/texasToday"; // TODO: add texasToday scraper
-import { run as runHornsLink } from "./scrapers/hornslink";
-import { run as runMccombs } from "./scrapers/mccombs";
+import { SCRAPERS } from './scrapers/registry';
 
 export type Env = {
   DB: D1Database;
@@ -119,9 +117,9 @@ export default {
       return;
     }
 
-    // The 6-hour scrape cron.
-    // ctx.waitUntil(runTexasToday(env)); // TODO: add texasToday scraper
-    ctx.waitUntil(runHornsLink(env));
-    ctx.waitUntil(runMccombs(env));
+    // The 6-hour scrape cron. Fires every scraper in the registry.
+    for (const scraper of SCRAPERS) {
+      ctx.waitUntil(scraper.run(env));
+    }
   },
 };


### PR DESCRIPTION
## Summary

Refactors the scraper layer so all three sources (HornsLink, Texas Today,
McCombs) share one ingest + normalize pipeline instead of each having
their own D1 upsert code. Also wires Texas Today into the cron, which
was still TODO on main.

## Motivation

Each scraper had its own `ParsedEvent` type, its own `UPSERT_SQL` string,
its own image-URL logic, and its own `sleep`/`fetchWithRetry` helpers.
Adding a new source meant copying ~200 lines. Small fixes (a new HTML
entity to decode, a schema tweak) had to be applied in three places.

This PR pulls the common pieces into `server/src/events/` and reduces
each scraper to source-specific parsing + one `ingestEvents()` call.

## What changed

**New shared modules under `server/src/events/`**
- `types.ts` — `NormalizedEvent`, the shape every scraper produces
- `normalize.ts` — `stripHtml`, `classifyAspectRatio`, `parseImageDimensions`,
  `fetchImageMeta`, `truncateLocation`, etc.
- `ingest.ts` — the only file that knows the D1 schema
- `polite-fetch.ts` — `fetchWithRetry` (429 backoff + retry) and `sleep`

**Registry**
- `scrapers/registry.ts` lists every scraper. `worker.ts` now iterates
  the list instead of calling each `run()` by name.

**Scrapers**
- `hornslink.ts` — 489 → 240 lines
- `texasToday.ts` — 451 → 240 lines, now wired into the cron
- `mccombs.ts` — 566 → 315 lines. Existing test file updated for the
  new shape (`NormalizedEvent` fields, renamed `extractMccombsEventId`)

**Behavior tweaks**
- Texas Today `DAYS_AHEAD` went from 365 → 30 (matches HornsLink)
- `locationShort` now falls back to the street address when Localist
  gives no venue name (research studies, off-campus events)
- Added HTML entities to `stripHtml`: `&le;`, `&ge;`, `&times;`, `&ndash;`, `&hellip;`
- Texas Today now uses `fetchWithRetry` (was a bare `fetch`, would die on any 429)

**Docs**
- `docs/org-profiles.md` explains why HornsLink events get org rows but
  Texas Today/McCombs don't, and outlines the claim/verify flow when we
  build it.

## Sample output (Texas Today, via preview route, now removed)

```json
{
  "source": "texas_today",
  "sourceEventId": "53292185745908",
  "title": "Sleep and Glucose in Diabetes Research Study",
  "startDatetime": "2026-07-02T06:00:00-05:00",
  "organization": {
    "sourceOrgId": null,
    "name": "College of Education",
    "profilePicture": null
  },
  "locationShort": "2109 SAN JACINTO BLVD , Austin, Texas...",
  "locationFull": "2109 SAN JACINTO BLVD , Austin, Texas 78712",
  "imageUrl": "https://localist-images.azureedge.net/photos/.../huge/....jpg",
  "imageAspectRatio": "horizontal",
  "description": "... BMI ≤ 45 kg/m^2 ...",
  "categories": [{ "id": "research", "name": "Research" }]
}
```

Note the `≤` (was `&le;` before this PR) and the address-based
`locationShort` (was `null`).

## Testing

- McCombs' existing test file (`mccombs.test.ts`) was updated for the
  renamed fields and new import paths. All prior assertions preserved.
- Manually curled the scrape endpoints against `wrangler dev` and
  verified events land in D1 with correct `host_organization_name` and
  `host_organization_id` (nullable) values.
  
  ## Output (scrape from texas today showing in app)
  
<img width="668" height="768" alt="image" src="https://github.com/user-attachments/assets/ac28a7d7-88cb-446b-8fdf-5632e9457584" />
