### PR TITLE
chore: unblock CI

### DIFF
--- a/app/components/MapViewWrapper.tsx
+++ b/app/components/MapViewWrapper.tsx
@@ -28,6 +28,10 @@ export default function MapViewWrapper({
   onPinPress,
   onMapPress,
 }: MapViewWrapperProps) {
+  // Hook must be called before any conditional return to satisfy the
+  // rules of hooks.
+  const pinJustPressed = useRef(false);
+
   if (Platform.OS === 'web') {
     return (
       <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
@@ -45,8 +49,6 @@ export default function MapViewWrapper({
       </View>
     );
   }
-
-  const pinJustPressed = useRef(false);
 
   return (
     <View style={{ flex: 1 }}>

--- a/server/src/scrapers/__fixtures__/mccombs/external-registration.html
+++ b/server/src/scrapers/__fixtures__/mccombs/external-registration.html
@@ -1,38 +1,38 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-	<meta charset="utf-8"/>
-	<title>McCombs+ Partner Info Session / Events Calendar - McCombs School of Business</title>
-	<script type="application/ld+json">
-	/*<![CDATA[*/
-	{
-		"@context": "http://schema.org/",
-		"@type": "Event",
-		"eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
-		"name": "McCombs+ Partner Info Session",
-		"startDate": "2026-07-10T17:00:00+00:00",
-		"endDate": "2026-07-10T18:00:00+00:00",
-		"eventStatus": "https://schema.org/EventScheduled",
-		"url": "https://calendar.mccombs.utexas.edu/mccombsplus/event/10977-mccombs-partner-info-session",
-		"description": "  Join the McCombs+ Experiential Learning team for a virtual introduction to our program.    Register at https://www.eventbrite.com/e/mccombs-partner-info-session-123456789. ",
-		"location": [
-			{
-				"@type": "Place",
-				"name": "Virtual Event",
-				"address": {
-					"@type": "PostalAddress",
-					"streetAddress": "Virtual Event"
-				}
-			}
-		],
-		"organizer": {
-			"@type": "Organization",
-			"name": "McCombs+ (McCombs School of Business - The University of Texas at Austin)",
-			"url": "https://calendar.mccombs.utexas.edu/mccombsplus/"
-		}
-	}
-	/*]]>*/
-	</script>
-</head>
-<body></body>
+  <head>
+    <meta charset="utf-8" />
+    <title>McCombs+ Partner Info Session / Events Calendar - McCombs School of Business</title>
+    <script type="application/ld+json">
+      /*<![CDATA[*/
+      {
+        "@context": "http://schema.org/",
+        "@type": "Event",
+        "eventAttendanceMode": "https://schema.org/OnlineEventAttendanceMode",
+        "name": "McCombs+ Partner Info Session",
+        "startDate": "2026-07-10T17:00:00+00:00",
+        "endDate": "2026-07-10T18:00:00+00:00",
+        "eventStatus": "https://schema.org/EventScheduled",
+        "url": "https://calendar.mccombs.utexas.edu/mccombsplus/event/10977-mccombs-partner-info-session",
+        "description": "  Join the McCombs+ Experiential Learning team for a virtual introduction to our program.    Register at https://www.eventbrite.com/e/mccombs-partner-info-session-123456789. ",
+        "location": [
+          {
+            "@type": "Place",
+            "name": "Virtual Event",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "Virtual Event"
+            }
+          }
+        ],
+        "organizer": {
+          "@type": "Organization",
+          "name": "McCombs+ (McCombs School of Business - The University of Texas at Austin)",
+          "url": "https://calendar.mccombs.utexas.edu/mccombsplus/"
+        }
+      }
+      /*]]>*/
+    </script>
+  </head>
+  <body></body>
 </html>

--- a/server/src/scrapers/__fixtures__/mccombs/no-flyer.html
+++ b/server/src/scrapers/__fixtures__/mccombs/no-flyer.html
@@ -1,38 +1,41 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-	<meta charset="utf-8"/>
-	<title>Global Sustainability Leadership Institute Info Session / Events Calendar - McCombs School of Business</title>
-	<script type="application/ld+json">
-	/*<![CDATA[*/
-	{
-		"@context": "http://schema.org/",
-		"@type": "Event",
-		"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-		"name": "Global Sustainability Leadership Institute Information Session + Mixer",
-		"startDate": "2026-08-25T22:30:00+00:00",
-		"endDate": "2026-08-25T22:30:00+00:00",
-		"eventStatus": "https://schema.org/EventScheduled",
-		"url": "https://calendar.mccombs.utexas.edu/gsli/event/11401-global-sustainability-leadership-institute",
-		"description": "Welcome to the Forty Acres, Longhorns! Join us for a brief information session about our offerings, then stay for a mixer for students interested in sustainability.",
-		"location": [
-			{
-				"@type": "Place",
-				"name": "CBA 3.302",
-				"address": {
-					"@type": "PostalAddress",
-					"streetAddress": "CBA 3.302"
-				}
-			}
-		],
-		"organizer": {
-			"@type": "Organization",
-			"name": "Global Sustainability Leadership Institute (McCombs School of Business - The University of Texas at Austin)",
-			"url": "https://calendar.mccombs.utexas.edu/gsli/"
-		}
-	}
-	/*]]>*/
-	</script>
-</head>
-<body></body>
+  <head>
+    <meta charset="utf-8" />
+    <title>
+      Global Sustainability Leadership Institute Info Session / Events Calendar - McCombs School of
+      Business
+    </title>
+    <script type="application/ld+json">
+      /*<![CDATA[*/
+      {
+        "@context": "http://schema.org/",
+        "@type": "Event",
+        "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+        "name": "Global Sustainability Leadership Institute Information Session + Mixer",
+        "startDate": "2026-08-25T22:30:00+00:00",
+        "endDate": "2026-08-25T22:30:00+00:00",
+        "eventStatus": "https://schema.org/EventScheduled",
+        "url": "https://calendar.mccombs.utexas.edu/gsli/event/11401-global-sustainability-leadership-institute",
+        "description": "Welcome to the Forty Acres, Longhorns! Join us for a brief information session about our offerings, then stay for a mixer for students interested in sustainability.",
+        "location": [
+          {
+            "@type": "Place",
+            "name": "CBA 3.302",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "CBA 3.302"
+            }
+          }
+        ],
+        "organizer": {
+          "@type": "Organization",
+          "name": "Global Sustainability Leadership Institute (McCombs School of Business - The University of Texas at Austin)",
+          "url": "https://calendar.mccombs.utexas.edu/gsli/"
+        }
+      }
+      /*]]>*/
+    </script>
+  </head>
+  <body></body>
 </html>

--- a/server/src/scrapers/__fixtures__/mccombs/rsvp-required.html
+++ b/server/src/scrapers/__fixtures__/mccombs/rsvp-required.html
@@ -1,38 +1,40 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-	<meta charset="utf-8"/>
-	<title>Herb Kelleher Center Speaker Series / Events Calendar - McCombs School of Business</title>
-	<script type="application/ld+json">
-	/*<![CDATA[*/
-	{
-		"@context": "http://schema.org/",
-		"@type": "Event",
-		"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-		"name": "Herb Kelleher Center Speaker Series: Leading Through Change",
-		"startDate": "2026-10-02T19:00:00+00:00",
-		"endDate": "2026-10-02T20:30:00+00:00",
-		"eventStatus": "https://schema.org/EventScheduled",
-		"url": "https://calendar.mccombs.utexas.edu/kelleher/event/12045-speaker-series-leading-through-change",
-		"description": "  Space is limited &amp; RSVP required to attend. Please arrive 15 minutes early for check-in. ",
-		"location": [
-			{
-				"@type": "Place",
-				"name": "AT&amp;T Hotel &amp; Conference Center, 1900 University Ave, Austin, TX 78705",
-				"address": {
-					"@type": "PostalAddress",
-					"streetAddress": "AT&amp;T Hotel &amp; Conference Center, 1900 University Ave, Austin, TX 78705"
-				}
-			}
-		],
-		"organizer": {
-			"@type": "Organization",
-			"name": "Herb Kelleher Center (McCombs School of Business - The University of Texas at Austin)",
-			"url": "https://calendar.mccombs.utexas.edu/kelleher/"
-		}
-	}
-	/*]]>*/
-	</script>
-</head>
-<body></body>
+  <head>
+    <meta charset="utf-8" />
+    <title>
+      Herb Kelleher Center Speaker Series / Events Calendar - McCombs School of Business
+    </title>
+    <script type="application/ld+json">
+      /*<![CDATA[*/
+      {
+        "@context": "http://schema.org/",
+        "@type": "Event",
+        "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+        "name": "Herb Kelleher Center Speaker Series: Leading Through Change",
+        "startDate": "2026-10-02T19:00:00+00:00",
+        "endDate": "2026-10-02T20:30:00+00:00",
+        "eventStatus": "https://schema.org/EventScheduled",
+        "url": "https://calendar.mccombs.utexas.edu/kelleher/event/12045-speaker-series-leading-through-change",
+        "description": "  Space is limited &amp; RSVP required to attend. Please arrive 15 minutes early for check-in. ",
+        "location": [
+          {
+            "@type": "Place",
+            "name": "AT&amp;T Hotel &amp; Conference Center, 1900 University Ave, Austin, TX 78705",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "AT&amp;T Hotel &amp; Conference Center, 1900 University Ave, Austin, TX 78705"
+            }
+          }
+        ],
+        "organizer": {
+          "@type": "Organization",
+          "name": "Herb Kelleher Center (McCombs School of Business - The University of Texas at Austin)",
+          "url": "https://calendar.mccombs.utexas.edu/kelleher/"
+        }
+      }
+      /*]]>*/
+    </script>
+  </head>
+  <body></body>
 </html>

--- a/server/src/scrapers/__fixtures__/mccombs/standard.html
+++ b/server/src/scrapers/__fixtures__/mccombs/standard.html
@@ -1,44 +1,46 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-	<meta charset="utf-8"/>
-	<title>MSITM Lunch and Learn: Data Careers / Events Calendar - McCombs School of Business</title>
-	<script type="application/ld+json">
-	/*<![CDATA[*/
-	{
-		"@context": "http://schema.org/",
-		"@type": "Event",
-		"eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
-		"name": "MSITM Lunch and Learn: Data Careers",
-		"startDate": "2026-09-15T17:00:00+00:00",
-		"endDate": "2026-09-15T18:00:00+00:00",
-		"eventStatus": "https://schema.org/EventScheduled",
-		"url": "https://calendar.mccombs.utexas.edu/msitm/event/12001-msitm-lunch-and-learn-data-careers",
-		"description": "  Join MSITM faculty and alumni for a panel on breaking into data careers.    Lunch will be provided. ",
-		"location": [
-			{
-				"@type": "Place",
-				"name": "GSB 2.122, 2110 Speedway, Austin, TX 78705",
-				"address": {
-					"@type": "PostalAddress",
-					"streetAddress": "GSB 2.122, 2110 Speedway, Austin, TX 78705"
-				}
-			}
-		],
-		"image": {
-			"@type": "ImageObject",
-			"url": "https://calendar.mccombs.utexas.edu/live/image/gid/9/width/600/height/600/crop/1/src_region/0,0,1200,800/lunch-and-learn-flyer.jpg",
-			"width": 0,
-			"height": 0
-		},
-		"organizer": {
-			"@type": "Organization",
-			"name": "MSITM (McCombs School of Business - The University of Texas at Austin)",
-			"url": "https://calendar.mccombs.utexas.edu/msitm/"
-		}
-	}
-	/*]]>*/
-	</script>
-</head>
-<body></body>
+  <head>
+    <meta charset="utf-8" />
+    <title>
+      MSITM Lunch and Learn: Data Careers / Events Calendar - McCombs School of Business
+    </title>
+    <script type="application/ld+json">
+      /*<![CDATA[*/
+      {
+        "@context": "http://schema.org/",
+        "@type": "Event",
+        "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+        "name": "MSITM Lunch and Learn: Data Careers",
+        "startDate": "2026-09-15T17:00:00+00:00",
+        "endDate": "2026-09-15T18:00:00+00:00",
+        "eventStatus": "https://schema.org/EventScheduled",
+        "url": "https://calendar.mccombs.utexas.edu/msitm/event/12001-msitm-lunch-and-learn-data-careers",
+        "description": "  Join MSITM faculty and alumni for a panel on breaking into data careers.    Lunch will be provided. ",
+        "location": [
+          {
+            "@type": "Place",
+            "name": "GSB 2.122, 2110 Speedway, Austin, TX 78705",
+            "address": {
+              "@type": "PostalAddress",
+              "streetAddress": "GSB 2.122, 2110 Speedway, Austin, TX 78705"
+            }
+          }
+        ],
+        "image": {
+          "@type": "ImageObject",
+          "url": "https://calendar.mccombs.utexas.edu/live/image/gid/9/width/600/height/600/crop/1/src_region/0,0,1200,800/lunch-and-learn-flyer.jpg",
+          "width": 0,
+          "height": 0
+        },
+        "organizer": {
+          "@type": "Organization",
+          "name": "MSITM (McCombs School of Business - The University of Texas at Austin)",
+          "url": "https://calendar.mccombs.utexas.edu/msitm/"
+        }
+      }
+      /*]]>*/
+    </script>
+  </head>
+  <body></body>
 </html>

--- a/server/test/scrapers/test_mccombs.ts
+++ b/server/test/scrapers/test_mccombs.ts
@@ -3,19 +3,22 @@ import { join } from 'path';
 import { describe, expect, it } from 'vitest';
 import { classifyAspectRatio, parseImageDimensions } from '../../src/events/normalize';
 import {
-    buildLocationFull,
-    buildLocationShort,
-    cleanHostOrganization,
-    decodeHtmlEntities,
-    extractLocs,
-    extractMccombsEventId,
-    extractRsvpUrl,
-    parseEventFromHtml,
-    upgradeImageUrl,
+  buildLocationFull,
+  buildLocationShort,
+  cleanHostOrganization,
+  decodeHtmlEntities,
+  extractLocs,
+  extractMccombsEventId,
+  extractRsvpUrl,
+  parseEventFromHtml,
+  upgradeImageUrl,
 } from '../../src/scrapers/mccombs';
 
 function loadFixture(name: string): string {
-  return readFileSync(join(__dirname, '..', '..', 'src', 'scrapers', '__fixtures__', 'mccombs', name), 'utf-8');
+  return readFileSync(
+    join(__dirname, '..', '..', 'src', 'scrapers', '__fixtures__', 'mccombs', name),
+    'utf-8',
+  );
 }
 
 describe('parseEventFromHtml', () => {

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,11 +1,8 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: "node",
-    include: [
-      "src/**/*.{test,spec}.{ts,tsx}",
-      "test/**/test_*.ts",
-    ],
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'test/**/test_*.ts'],
   },
 });


### PR DESCRIPTION
- MapViewWrapper: move useRef above the web platform early return (rules-of-hooks violation).
- Format 6 pre-existing files that failed prettier --check.