### PR TITLE
LOOP-151: Add authenticated user-created event endpoint with R2 image uploads

### DIFF
--- a/app/(create-event)/OptionalExtras.tsx
+++ b/app/(create-event)/OptionalExtras.tsx
@@ -1,5 +1,10 @@
 import ImagePlusIcon from '@/assets/images/image-plus.svg';
 import { useCreateEvent } from '@/app/context/CreateEventContext';
+import type { CreateEventData } from '@/app/context/CreateEventContext';
+import { useOnboarding } from '@/app/context/OnboardingContext';
+import { ApiError, api } from '@/app/lib/api';
+import { events as eventsKeys, explore as exploreKeys } from '@/app/lib/queryKeys';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Image } from 'expo-image';
 import * as ImagePicker from 'expo-image-picker';
 import { useRouter } from 'expo-router';
@@ -24,14 +29,140 @@ const INPUT_BORDER = '#00000033';
 const BG = '#F9F8F5';
 const TEXT_SECONDARY = '#485656';
 
+type CreateEventResponse = { event: unknown };
+
+function appendOptional(form: FormData, key: string, value: string | null | undefined) {
+  const trimmed = value?.trim();
+  if (trimmed) form.append(key, trimmed);
+}
+
+function getFileNameFromUri(uri: string): string {
+  const fallback = 'event-image.jpg';
+  const withoutQuery = uri.split('?')[0] ?? uri;
+  const lastSegment = withoutQuery.split('/').filter(Boolean).pop();
+  if (!lastSegment) return fallback;
+
+  try {
+    return decodeURIComponent(lastSegment);
+  } catch {
+    return lastSegment;
+  }
+}
+
+function inferImageMimeType(fileName: string, pickerMimeType: string | null): string {
+  if (pickerMimeType?.startsWith('image/')) return pickerMimeType;
+
+  const extension = fileName.split('.').pop()?.toLowerCase();
+  if (extension === 'png') return 'image/png';
+  if (extension === 'gif') return 'image/gif';
+  if (extension === 'webp') return 'image/webp';
+  return 'image/jpeg';
+}
+
+async function appendImageToForm(form: FormData, data: CreateEventData): Promise<void> {
+  if (!data.imageUrl) return;
+
+  const fileName = data.imageName ?? getFileNameFromUri(data.imageUrl);
+  const mimeType = inferImageMimeType(fileName, data.imageMimeType);
+
+  if (Platform.OS === 'web') {
+    const response = await fetch(data.imageUrl);
+    if (!response.ok) throw new Error('IMAGE_READ_FAILED');
+
+    const blob = await response.blob();
+    const uploadBlob =
+      blob.type === mimeType ? blob : new Blob([await blob.arrayBuffer()], { type: mimeType });
+    form.append('image', uploadBlob, fileName);
+    return;
+  }
+
+  form.append(
+    'image',
+    {
+      uri: data.imageUrl,
+      name: fileName,
+      type: mimeType,
+    } as unknown as Blob,
+  );
+}
+
+async function buildCreateEventForm(data: CreateEventData): Promise<FormData> {
+  const form = new FormData();
+
+  form.append('title', data.title.trim());
+  appendOptional(form, 'description', data.description);
+  if (data.startDatetime) form.append('start_datetime', data.startDatetime);
+  if (data.dateMode === 'range' && data.endDatetime) {
+    form.append('end_datetime', data.endDatetime);
+  }
+  appendOptional(form, 'location', data.locationFull);
+  appendOptional(form, 'rsvp_url', data.rsvpUrl);
+  if (data.discoveryBucket) form.append('discoveryBucket', data.discoveryBucket);
+  if (data.eventType) form.append('event_type', data.eventType);
+  if (data.interestTags.length > 0) {
+    form.append('categories', JSON.stringify(data.interestTags));
+  }
+
+  await appendImageToForm(form, data);
+
+  return form;
+}
+
+function getCreateEventErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message === 'AUTH_REQUIRED') {
+    return 'Please sign in before posting an event.';
+  }
+  if (error instanceof Error && error.message === 'MISSING_REQUIRED_FIELDS') {
+    return 'Add an event title and start time before posting.';
+  }
+  if (error instanceof Error && error.message === 'IMAGE_READ_FAILED') {
+    return 'Could not read the selected image. Try choosing it again.';
+  }
+  if (error instanceof ApiError) {
+    if (error.status === 401) return 'Please sign in again before posting this event.';
+    if (error.body && typeof error.body === 'object' && 'fields' in error.body) {
+      const fields = (error.body as { fields?: Record<string, string> }).fields;
+      const firstError = fields ? Object.values(fields)[0] : null;
+      if (firstError) return firstError;
+    }
+    return error.message;
+  }
+  return 'Something went wrong while posting your event. Please try again.';
+}
+
 export default function OptionalExtras() {
   const router = useRouter();
   const { data, update, reset } = useCreateEvent();
+  const { data: onboarding } = useOnboarding();
+  const queryClient = useQueryClient();
+  const token = onboarding.token || null;
+
+  const createEvent = useMutation<CreateEventResponse>({
+    mutationFn: async () => {
+      if (!token && !__DEV__) throw new Error('AUTH_REQUIRED');
+      if (!data.title.trim() || !data.startDatetime) throw new Error('MISSING_REQUIRED_FIELDS');
+      const form = await buildCreateEventForm(data);
+      return api.postForm<CreateEventResponse>('/events/create', form, {
+        token,
+      });
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: eventsKeys.lists() }),
+        queryClient.invalidateQueries({ queryKey: exploreKeys.all }),
+      ]);
+      reset();
+      router.replace('/(tabs)/home?justPostedEvent=1');
+    },
+    onError: (error) => {
+      if (__DEV__) {
+        console.error('Create event failed', error);
+      }
+      Alert.alert('Could not post event', getCreateEventErrorMessage(error));
+    },
+  });
 
   const onUpload = async () => {
-    // TODO: currently just holds a local URI in context. When the POST
-    // endpoint is wired, upload the file to storage first and swap the
-    // local URI for the permanent URL before submitting the event.
     const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (!permission.granted) {
       Alert.alert(
@@ -49,8 +180,14 @@ export default function OptionalExtras() {
     });
 
     if (result.canceled) return;
-    const uri = result.assets[0]?.uri;
-    if (uri) update({ imageUrl: uri });
+    const asset = result.assets[0];
+    if (asset?.uri) {
+      update({
+        imageUrl: asset.uri,
+        imageName: asset.fileName ?? null,
+        imageMimeType: asset.mimeType ?? null,
+      });
+    }
   };
 
   const onPreview = () => {
@@ -60,16 +197,16 @@ export default function OptionalExtras() {
   };
 
   const onPost = () => {
-    // TODO: replace with a real POST once the backend endpoint is wired.
-    //   1. POST /events with the context payload
-    //   2. On 2xx, invalidate the events + user's-events queries
-    //   3. Attach the created event to the poster's profile so it shows
-    //      up in their event list
-    //   4. Only then reset() and route home
-    // For now we optimistically reset and route straight to home; the
-    // ?justPostedEvent=1 param triggers the success modal there.
-    reset();
-    router.replace('/(tabs)/home?justPostedEvent=1');
+    if (createEvent.isPending) return;
+    if (!token && !__DEV__) {
+      Alert.alert('Sign in required', 'Please sign in before posting an event.');
+      return;
+    }
+    if (!data.title.trim() || !data.startDatetime) {
+      Alert.alert('Missing details', 'Add an event title and start time before posting.');
+      return;
+    }
+    createEvent.mutate();
   };
 
   return (
@@ -156,17 +293,23 @@ export default function OptionalExtras() {
           <View style={styles.buttonRow}>
             <TouchableOpacity
               onPress={onPreview}
-              activeOpacity={0.85}
+              activeOpacity={createEvent.isPending ? 1 : 0.85}
+              disabled={createEvent.isPending}
               style={[styles.actionButton, styles.previewButton]}
             >
               <Text style={styles.previewText}>Preview Event</Text>
             </TouchableOpacity>
             <TouchableOpacity
               onPress={onPost}
-              activeOpacity={0.85}
-              style={[styles.actionButton, styles.postButton]}
+              activeOpacity={createEvent.isPending ? 1 : 0.85}
+              disabled={createEvent.isPending}
+              style={[
+                styles.actionButton,
+                styles.postButton,
+                createEvent.isPending && styles.actionButtonDisabled,
+              ]}
             >
-              <Text style={styles.postText}>Post Event</Text>
+              <Text style={styles.postText}>{createEvent.isPending ? 'Posting...' : 'Post Event'}</Text>
             </TouchableOpacity>
           </View>
         </ScrollView>
@@ -298,6 +441,9 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  actionButtonDisabled: {
+    opacity: 0.65,
   },
   previewButton: {
     backgroundColor: CARD_BG,

--- a/app/(create-event)/OptionalExtras.tsx
+++ b/app/(create-event)/OptionalExtras.tsx
@@ -76,14 +76,11 @@ async function appendImageToForm(form: FormData, data: CreateEventData): Promise
     return;
   }
 
-  form.append(
-    'image',
-    {
-      uri: data.imageUrl,
-      name: fileName,
-      type: mimeType,
-    } as unknown as Blob,
-  );
+  form.append('image', {
+    uri: data.imageUrl,
+    name: fileName,
+    type: mimeType,
+  } as unknown as Blob);
 }
 
 async function buildCreateEventForm(data: CreateEventData): Promise<FormData> {
@@ -139,7 +136,7 @@ export default function OptionalExtras() {
 
   const createEvent = useMutation<CreateEventResponse>({
     mutationFn: async () => {
-      if (!token && !__DEV__) throw new Error('AUTH_REQUIRED');
+      if (!token) throw new Error('AUTH_REQUIRED');
       if (!data.title.trim() || !data.startDatetime) throw new Error('MISSING_REQUIRED_FIELDS');
       const form = await buildCreateEventForm(data);
       return api.postForm<CreateEventResponse>('/events/create', form, {
@@ -198,7 +195,7 @@ export default function OptionalExtras() {
 
   const onPost = () => {
     if (createEvent.isPending) return;
-    if (!token && !__DEV__) {
+    if (!token) {
       Alert.alert('Sign in required', 'Please sign in before posting an event.');
       return;
     }
@@ -309,7 +306,9 @@ export default function OptionalExtras() {
                 createEvent.isPending && styles.actionButtonDisabled,
               ]}
             >
-              <Text style={styles.postText}>{createEvent.isPending ? 'Posting...' : 'Post Event'}</Text>
+              <Text style={styles.postText}>
+                {createEvent.isPending ? 'Posting...' : 'Post Event'}
+              </Text>
             </TouchableOpacity>
           </View>
         </ScrollView>

--- a/app/context/CreateEventContext.tsx
+++ b/app/context/CreateEventContext.tsx
@@ -57,6 +57,8 @@ export interface CreateEventData {
   locationFull: string;
   rsvpUrl: string;
   imageUrl: string | null;
+  imageName: string | null;
+  imageMimeType: string | null;
 }
 
 interface CreateEventContextType {
@@ -78,6 +80,8 @@ const DEFAULT_DATA: CreateEventData = {
   locationFull: '',
   rsvpUrl: '',
   imageUrl: null,
+  imageName: null,
+  imageMimeType: null,
 };
 
 const CreateEventContext = createContext<CreateEventContextType>({

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -26,22 +26,12 @@ interface RequestOptions {
   signal?: AbortSignal;
 }
 
-async function request<T>(
-  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
-  path: string,
-  opts: RequestOptions = {},
-): Promise<T> {
-  const headers: Record<string, string> = {};
-  if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
-  if (opts.token) headers['Authorization'] = `Bearer ${opts.token}`;
+interface FormRequestOptions {
+  token?: string | null;
+  signal?: AbortSignal;
+}
 
-  const res = await fetch(`${API_BASE_URL}${path}`, {
-    method,
-    headers,
-    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
-    signal: opts.signal,
-  });
-
+async function parseResponse<T>(res: Response): Promise<T> {
   // Try to parse JSON, but tolerate empty bodies / non-JSON errors.
   let parsed: unknown = null;
   const text = await res.text();
@@ -64,9 +54,49 @@ async function request<T>(
   return parsed as T;
 }
 
+async function request<T>(
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+  path: string,
+  opts: RequestOptions = {},
+): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+  if (opts.token) headers['Authorization'] = `Bearer ${opts.token}`;
+
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers,
+    body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+    signal: opts.signal,
+  });
+
+  return parseResponse<T>(res);
+}
+
+async function requestForm<T>(
+  method: 'POST' | 'PUT' | 'PATCH',
+  path: string,
+  form: FormData,
+  opts: FormRequestOptions = {},
+): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (opts.token) headers['Authorization'] = `Bearer ${opts.token}`;
+
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers,
+    body: form,
+    signal: opts.signal,
+  });
+
+  return parseResponse<T>(res);
+}
+
 export const api = {
   get: <T>(path: string, opts?: RequestOptions) => request<T>('GET', path, opts),
   post: <T>(path: string, opts?: RequestOptions) => request<T>('POST', path, opts),
+  postForm: <T>(path: string, form: FormData, opts?: FormRequestOptions) =>
+    requestForm<T>('POST', path, form, opts),
   put: <T>(path: string, opts?: RequestOptions) => request<T>('PUT', path, opts),
   patch: <T>(path: string, opts?: RequestOptions) => request<T>('PATCH', path, opts),
   delete: <T>(path: string, opts?: RequestOptions) => request<T>('DELETE', path, opts),

--- a/server/.dev.vars.example
+++ b/server/.dev.vars.example
@@ -8,7 +8,16 @@ JWT_SECRET=local-dev-jwt-secret-change-me
 # Get one at https://resend.com (free tier OK).
 RESEND_API_KEY=
 
+# Public URL base for objects in the EVENT_IMAGES R2 bucket. Use the
+# bucket's r2.dev public URL or a custom domain, without a trailing slash.
+EVENT_IMAGE_PUBLIC_BASE_URL=
+
 # When "true", the Worker logs verification codes to the console instead of
 # emailing them. Lets you test signup locally without a verified Resend
 # domain. Never set this in production.
 RESEND_DEV_MODE=true
+
+# Local testing only. When true, POST /events/create accepts requests with no
+# JWT and attributes them to dev-event-create@utexas.edu. Never set this in
+# production.
+DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE=false

--- a/server/.dev.vars.example
+++ b/server/.dev.vars.example
@@ -16,8 +16,3 @@ EVENT_IMAGE_PUBLIC_BASE_URL=
 # emailing them. Lets you test signup locally without a verified Resend
 # domain. Never set this in production.
 RESEND_DEV_MODE=true
-
-# Local testing only. When true, POST /events/create accepts requests with no
-# JWT and attributes them to dev-event-create@utexas.edu. Never set this in
-# production.
-DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE=false

--- a/server/README.md
+++ b/server/README.md
@@ -46,6 +46,16 @@ to log what would be written without touching D1, or omit it (or set
 - `.dev.vars.example` — template, committed.
 - Production secrets — set via `wrangler secret put NAME` (needs Cloudflare access).
 
+## Event Images
+
+User-created event uploads are stored in the `longhorn-loop-event-images`
+R2 bucket through the Worker binding `EVENT_IMAGES`.
+
+Set `EVENT_IMAGE_PUBLIC_BASE_URL` to the bucket's public r2.dev URL or a
+custom domain, without a trailing slash. Uploaded objects are written under
+`events/user-created/{userId}/{uuid}.{ext}` and the event row stores
+`EVENT_IMAGE_PUBLIC_BASE_URL` plus that object key.
+
 ### `RESEND_DEV_MODE`
 
 When `RESEND_DEV_MODE=true`, `/auth/send-code` prints the verification

--- a/server/src/routes/events.worker.ts
+++ b/server/src/routes/events.worker.ts
@@ -13,7 +13,6 @@ const REPORT_HIDE_THRESHOLD = 5;
 
 const REPORT_REASONS = new Set(['violent_harmful', 'misinformation', 'troll_spam', 'other']);
 const USER_CREATED_SOURCE = 'user_created';
-const DEV_CREATE_EVENT_EMAIL = 'dev-event-create@utexas.edu';
 const MAX_TITLE_LENGTH = 80;
 const MAX_DESCRIPTION_LENGTH = 500;
 const MAX_LOCATION_LENGTH = 200;
@@ -30,12 +29,7 @@ const VALID_IMAGE_ASPECT_RATIOS = new Set<ImageAspectRatio>([
   'horizontal',
   'none',
 ]);
-const ALLOWED_IMAGE_MIME_TYPES = new Set([
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-  'image/webp',
-]);
+const ALLOWED_IMAGE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
 const THEME_BY_DISCOVERY_BUCKET: Record<string, string> = {
   music: 'Music',
   arts: 'Arts',
@@ -129,38 +123,6 @@ async function getUserByEmail(db: D1Database, email: string): Promise<AuthDbUser
     first_name: (row.first_name as string | null | undefined) ?? null,
     last_name: (row.last_name as string | null | undefined) ?? null,
   };
-}
-
-async function getOrCreateDevCreateEventUser(db: D1Database): Promise<AuthDbUser> {
-  await db
-    .prepare(
-      `INSERT INTO users (email, first_name, last_name, onboarding_completed)
-       VALUES (?, 'Dev', 'User', 1)
-       ON CONFLICT(email) DO UPDATE SET
-         first_name = excluded.first_name,
-         last_name = excluded.last_name`,
-    )
-    .bind(DEV_CREATE_EVENT_EMAIL)
-    .run();
-
-  const user = await getUserByEmail(db, DEV_CREATE_EVENT_EMAIL);
-  if (!user) throw new Error('Failed to create dev event user');
-  return user;
-}
-
-async function getCreateEventUser(c: {
-  env: Env;
-  req: { header: (name: string) => string | undefined };
-}): Promise<AuthDbUser | null> {
-  const authHeader = c.req.header('Authorization');
-  const auth = await getAuthUser(authHeader, c.env.JWT_SECRET);
-  if (auth) return getUserByEmail(c.env.DB, auth.email);
-
-  if (!authHeader && c.env.DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE === 'true') {
-    return getOrCreateDevCreateEventUser(c.env.DB);
-  }
-
-  return null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -273,11 +235,7 @@ function truncateLocation(location: string | null): string | null {
   return `${location.slice(0, 37)}...`;
 }
 
-function validateUrl(
-  value: string | null,
-  field: string,
-  errors: ValidationErrors,
-): string | null {
+function validateUrl(value: string | null, field: string, errors: ValidationErrors): string | null {
   if (!value) return null;
   if (value.length > MAX_URL_LENGTH) {
     errors[field] = `Must be ${MAX_URL_LENGTH} characters or fewer`;
@@ -305,7 +263,10 @@ function slugifyCategoryId(name: string, index: number): string {
   return slug || `category-${index + 1}`;
 }
 
-function normalizeCategories(body: CreateEventBody, errors: ValidationErrors): NormalizedCategory[] {
+function normalizeCategories(
+  body: CreateEventBody,
+  errors: ValidationErrors,
+): NormalizedCategory[] {
   const raw = body.categories ?? body.interestTags ?? body.interest_tags;
   if (raw === undefined || raw === null) return [];
   if (!Array.isArray(raw)) {
@@ -401,7 +362,12 @@ function parseImageUrlFields(
     errors,
   );
   const imageAspectRatio = normalizeAspectRatio(
-    readStringField(metadata, ['image_aspect_ratio', 'imageAspectRatio', 'aspect_ratio', 'aspectRatio']),
+    readStringField(metadata, [
+      'image_aspect_ratio',
+      'imageAspectRatio',
+      'aspect_ratio',
+      'aspectRatio',
+    ]),
     imageWidth,
     imageHeight,
     true,
@@ -418,7 +384,10 @@ function parseImageUrlFields(
   };
 }
 
-function parseDataImage(input: string, fallbackMimeType: string | null): {
+function parseDataImage(
+  input: string,
+  fallbackMimeType: string | null,
+): {
   bytes: Uint8Array;
   mimeType: string;
 } | null {
@@ -615,7 +584,10 @@ async function resolveImageFields(
     const imageString = image.trim();
     if (imageString.length > 0) {
       if (imageString.startsWith('data:')) {
-        const parsed = parseDataImage(imageString, readStringField(body, ['image_mime_type', 'imageMimeType']));
+        const parsed = parseDataImage(
+          imageString,
+          readStringField(body, ['image_mime_type', 'imageMimeType']),
+        );
         if (!parsed) {
           errors.image = 'Must include valid base64 image data and a MIME type';
           return empty;
@@ -628,7 +600,10 @@ async function resolveImageFields(
 
   const imageBase64 = readStringField(body, ['image_base64', 'imageBase64']);
   if (imageBase64) {
-    const parsed = parseDataImage(imageBase64, readStringField(body, ['image_mime_type', 'imageMimeType']));
+    const parsed = parseDataImage(
+      imageBase64,
+      readStringField(body, ['image_mime_type', 'imageMimeType']),
+    );
     if (!parsed) {
       errors.image = 'Must include valid base64 image data and a MIME type';
       return empty;
@@ -656,7 +631,10 @@ function getHostName(body: CreateEventBody, user: AuthDbUser): string {
   return name || user.email;
 }
 
-async function getCreatedEvent(db: D1Database, eventId: number): Promise<Record<string, unknown> | null> {
+async function getCreatedEvent(
+  db: D1Database,
+  eventId: number,
+): Promise<Record<string, unknown> | null> {
   const event = await db
     .prepare(
       `SELECT e.*, o.profile_picture as org_profile_picture
@@ -715,23 +693,17 @@ function buildVisibilityFilter(userId: number | null): {
 
 // POST /events/create -- authenticated users create their own events.
 eventRoutes.post('/create', async (c) => {
-  const hasAuthHeader = !!c.req.header('Authorization');
-  const user = await getCreateEventUser(c);
-  if (!user) {
-    return c.json({ error: hasAuthHeader ? 'USER_NOT_FOUND' : 'UNAUTHORIZED' }, 401);
-  }
+  const auth = await getAuthUser(c.req.header('Authorization'), c.env.JWT_SECRET);
+  if (!auth) return c.json({ error: 'UNAUTHORIZED' }, 401);
+
+  const user = await getUserByEmail(c.env.DB, auth.email);
+  if (!user) return c.json({ error: 'USER_NOT_FOUND' }, 401);
 
   const { body, uploadedImage, malformed } = await readCreateEventBody(c.req.raw);
   if (malformed || !body) return c.json({ error: 'INVALID_BODY' }, 400);
 
   const errors: ValidationErrors = {};
-  const title = parseRequiredString(
-    body,
-    ['title'],
-    'title',
-    MAX_TITLE_LENGTH,
-    errors,
-  );
+  const title = parseRequiredString(body, ['title'], 'title', MAX_TITLE_LENGTH, errors);
   const description = parseOptionalString(
     body,
     ['description'],
@@ -753,13 +725,23 @@ eventRoutes.post('/create', async (c) => {
   );
   const endDatetime = rawEndDatetime ?? startDatetime;
 
-  if (startDatetime && endDatetime && new Date(endDatetime).getTime() < new Date(startDatetime).getTime()) {
+  if (
+    startDatetime &&
+    endDatetime &&
+    new Date(endDatetime).getTime() < new Date(startDatetime).getTime()
+  ) {
     errors.end_datetime = 'Must be on or after start_datetime';
   }
 
   const locationObject = isRecord(body.location) ? body.location : null;
   const locationFull =
-    parseOptionalString(body, ['location_full', 'locationFull'], 'location_full', MAX_LOCATION_LENGTH, errors) ??
+    parseOptionalString(
+      body,
+      ['location_full', 'locationFull'],
+      'location_full',
+      MAX_LOCATION_LENGTH,
+      errors,
+    ) ??
     parseOptionalString(
       locationObject ?? {},
       ['full', 'full_name', 'fullName', 'name'],
@@ -770,13 +752,15 @@ eventRoutes.post('/create', async (c) => {
     parseOptionalString(body, ['location'], 'location', MAX_LOCATION_LENGTH, errors);
   const locationShort =
     parseOptionalString(body, ['location_short', 'locationShort'], 'location_short', 40, errors) ??
-    parseOptionalString(locationObject ?? {}, ['short', 'short_name', 'shortName'], 'location_short', 40, errors) ??
+    parseOptionalString(
+      locationObject ?? {},
+      ['short', 'short_name', 'shortName'],
+      'location_short',
+      40,
+      errors,
+    ) ??
     truncateLocation(locationFull);
-  const rsvpUrl = validateUrl(
-    readStringField(body, ['rsvp_url', 'rsvpUrl']),
-    'rsvp_url',
-    errors,
-  );
+  const rsvpUrl = validateUrl(readStringField(body, ['rsvp_url', 'rsvpUrl']), 'rsvp_url', errors);
   const eventUrl = validateUrl(
     readStringField(body, ['event_url', 'eventUrl']),
     'event_url',
@@ -786,7 +770,7 @@ eventRoutes.post('/create', async (c) => {
     parseOptionalString(body, ['theme'], 'theme', 80, errors) ??
     (() => {
       const discoveryBucket = readStringField(body, ['discovery_bucket', 'discoveryBucket']);
-      return discoveryBucket ? THEME_BY_DISCOVERY_BUCKET[discoveryBucket] ?? null : null;
+      return discoveryBucket ? (THEME_BY_DISCOVERY_BUCKET[discoveryBucket] ?? null) : null;
     })();
   const latitude = readNumberField(body, ['latitude', 'lat']);
   const longitude = readNumberField(body, ['longitude', 'lng', 'lon']);

--- a/server/src/routes/events.worker.ts
+++ b/server/src/routes/events.worker.ts
@@ -1,5 +1,7 @@
 // Events routes for Cloudflare Worker
 import { Hono } from 'hono';
+import { classifyAspectRatio, parseImageDimensions } from '../events/normalize';
+import type { ImageAspectRatio } from '../events/types';
 import { scrapeHornsLink } from '../scrapers/hornslink';
 import { scrapeMccombs } from '../scrapers/mccombs';
 import type { Env } from '../worker';
@@ -10,6 +12,76 @@ export const eventRoutes = new Hono<{ Bindings: Env }>();
 const REPORT_HIDE_THRESHOLD = 5;
 
 const REPORT_REASONS = new Set(['violent_harmful', 'misinformation', 'troll_spam', 'other']);
+const USER_CREATED_SOURCE = 'user_created';
+const DEV_CREATE_EVENT_EMAIL = 'dev-event-create@utexas.edu';
+const MAX_TITLE_LENGTH = 80;
+const MAX_DESCRIPTION_LENGTH = 500;
+const MAX_LOCATION_LENGTH = 200;
+const MAX_URL_LENGTH = 2048;
+const MAX_CATEGORY_COUNT = 20;
+const MAX_CATEGORY_NAME_LENGTH = 120;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const EXPIRES_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+const ISO_8601_WITH_TIMEZONE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d{1,3})?)?(?:Z|[+-]\d{2}:\d{2})$/;
+const VALID_IMAGE_ASPECT_RATIOS = new Set<ImageAspectRatio>([
+  'vertical',
+  'square',
+  'horizontal',
+  'none',
+]);
+const ALLOWED_IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+]);
+const THEME_BY_DISCOVERY_BUCKET: Record<string, string> = {
+  music: 'Music',
+  arts: 'Arts',
+  sports: 'Sports',
+  food: 'Social',
+  tech: 'Technology',
+  education: 'Academic',
+  learning: 'Academic',
+  outdoors: 'Outdoors',
+  gaming: 'Social',
+  social: 'Social',
+  health: 'Health',
+  shopping: 'Social',
+  business: 'Business',
+  performing: 'Arts',
+  travel: 'Social',
+  pets: 'Social',
+  home: 'Social',
+  nightlife: 'Social',
+  science: 'Academic',
+  spirituality: 'Spirituality',
+};
+
+type ValidationErrors = Record<string, string>;
+type CreateEventBody = Record<string, unknown>;
+
+type AuthDbUser = {
+  id: number;
+  email: string;
+  first_name?: string | null;
+  last_name?: string | null;
+};
+
+type NormalizedCategory = {
+  id: string;
+  name: string | null;
+};
+
+type ImageFields = {
+  imageUrl: string | null;
+  imageWidth: number | null;
+  imageHeight: number | null;
+  imageAspectRatio: ImageAspectRatio;
+  imageMimeType: string | null;
+  imageAltText: string | null;
+};
 
 // JWT verification (mirrors the pattern used in saved.worker.ts).
 async function getAuthUser(
@@ -45,6 +117,578 @@ async function getUserId(db: D1Database, email: string): Promise<number | null> 
   return row ? (row.id as number) : null;
 }
 
+async function getUserByEmail(db: D1Database, email: string): Promise<AuthDbUser | null> {
+  const row = await db
+    .prepare('SELECT id, email, first_name, last_name FROM users WHERE email = ?')
+    .bind(email)
+    .first();
+  if (!row) return null;
+  return {
+    id: row.id as number,
+    email: row.email as string,
+    first_name: (row.first_name as string | null | undefined) ?? null,
+    last_name: (row.last_name as string | null | undefined) ?? null,
+  };
+}
+
+async function getOrCreateDevCreateEventUser(db: D1Database): Promise<AuthDbUser> {
+  await db
+    .prepare(
+      `INSERT INTO users (email, first_name, last_name, onboarding_completed)
+       VALUES (?, 'Dev', 'User', 1)
+       ON CONFLICT(email) DO UPDATE SET
+         first_name = excluded.first_name,
+         last_name = excluded.last_name`,
+    )
+    .bind(DEV_CREATE_EVENT_EMAIL)
+    .run();
+
+  const user = await getUserByEmail(db, DEV_CREATE_EVENT_EMAIL);
+  if (!user) throw new Error('Failed to create dev event user');
+  return user;
+}
+
+async function getCreateEventUser(c: {
+  env: Env;
+  req: { header: (name: string) => string | undefined };
+}): Promise<AuthDbUser | null> {
+  const authHeader = c.req.header('Authorization');
+  const auth = await getAuthUser(authHeader, c.env.JWT_SECRET);
+  if (auth) return getUserByEmail(c.env.DB, auth.email);
+
+  if (!authHeader && c.env.DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE === 'true') {
+    return getOrCreateDevCreateEventUser(c.env.DB);
+  }
+
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cleanString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function readStringField(body: CreateEventBody, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = cleanString(body[key]);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function readIntegerField(body: CreateEventBody, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = body[key];
+    if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value;
+    if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
+      const parsed = Number(value);
+      if (Number.isSafeInteger(parsed) && parsed > 0) return parsed;
+    }
+  }
+  return null;
+}
+
+function readNumberField(body: CreateEventBody, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = body[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string' && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return null;
+}
+
+function parseRequiredString(
+  body: CreateEventBody,
+  keys: string[],
+  field: string,
+  maxLength: number,
+  errors: ValidationErrors,
+): string | null {
+  const value = readStringField(body, keys);
+  if (!value) {
+    errors[field] = 'Required';
+    return null;
+  }
+  if (value.length > maxLength) {
+    errors[field] = `Must be ${maxLength} characters or fewer`;
+    return null;
+  }
+  return value;
+}
+
+function parseOptionalString(
+  body: CreateEventBody,
+  keys: string[],
+  field: string,
+  maxLength: number,
+  errors: ValidationErrors,
+): string | null {
+  const value = readStringField(body, keys);
+  if (!value) return null;
+  if (value.length > maxLength) {
+    errors[field] = `Must be ${maxLength} characters or fewer`;
+    return null;
+  }
+  return value;
+}
+
+function parseIsoDatetime(
+  value: string | null,
+  field: string,
+  required: boolean,
+  errors: ValidationErrors,
+): string | null {
+  if (!value) {
+    if (required) errors[field] = 'Required';
+    return null;
+  }
+  if (!ISO_8601_WITH_TIMEZONE.test(value)) {
+    errors[field] = 'Must be an ISO 8601 datetime with timezone';
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    errors[field] = 'Must be a valid datetime';
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+function computeExpiresAt(endDatetime: string, startDatetime: string): string {
+  const base = endDatetime || startDatetime;
+  return new Date(new Date(base).getTime() + EXPIRES_AFTER_MS).toISOString();
+}
+
+function truncateLocation(location: string | null): string | null {
+  if (!location) return null;
+  if (location.length <= 40) return location;
+  return `${location.slice(0, 37)}...`;
+}
+
+function validateUrl(
+  value: string | null,
+  field: string,
+  errors: ValidationErrors,
+): string | null {
+  if (!value) return null;
+  if (value.length > MAX_URL_LENGTH) {
+    errors[field] = `Must be ${MAX_URL_LENGTH} characters or fewer`;
+    return null;
+  }
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      errors[field] = 'Must be an http or https URL';
+      return null;
+    }
+    return url.toString();
+  } catch {
+    errors[field] = 'Must be a valid URL';
+    return null;
+  }
+}
+
+function slugifyCategoryId(name: string, index: number): string {
+  const slug = name
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug || `category-${index + 1}`;
+}
+
+function normalizeCategories(body: CreateEventBody, errors: ValidationErrors): NormalizedCategory[] {
+  const raw = body.categories ?? body.interestTags ?? body.interest_tags;
+  if (raw === undefined || raw === null) return [];
+  if (!Array.isArray(raw)) {
+    errors.categories = 'Must be an array';
+    return [];
+  }
+  if (raw.length > MAX_CATEGORY_COUNT) {
+    errors.categories = `Must include ${MAX_CATEGORY_COUNT} categories or fewer`;
+    return [];
+  }
+
+  const categories: NormalizedCategory[] = [];
+  const seen = new Set<string>();
+  raw.forEach((item, index) => {
+    let id: string | null = null;
+    let name: string | null = null;
+
+    if (typeof item === 'string') {
+      name = cleanString(item);
+      id = name ? slugifyCategoryId(name, index) : null;
+    } else if (isRecord(item)) {
+      name =
+        readStringField(item, ['name', 'category_name', 'categoryName', 'label']) ??
+        readStringField(item, ['id', 'category_id', 'categoryId']);
+      id = readStringField(item, ['id', 'category_id', 'categoryId']);
+      if (!id && name) id = slugifyCategoryId(name, index);
+    }
+
+    if (!id) {
+      errors.categories = 'Each category must be a string or include an id/name';
+      return;
+    }
+    if (id.length > MAX_CATEGORY_NAME_LENGTH || (name && name.length > MAX_CATEGORY_NAME_LENGTH)) {
+      errors.categories = `Category values must be ${MAX_CATEGORY_NAME_LENGTH} characters or fewer`;
+      return;
+    }
+
+    const dedupeKey = id.toLowerCase();
+    if (!seen.has(dedupeKey)) {
+      seen.add(dedupeKey);
+      categories.push({ id, name });
+    }
+  });
+
+  return errors.categories ? [] : categories;
+}
+
+function normalizeAspectRatio(
+  raw: string | null,
+  width: number | null,
+  height: number | null,
+  hasImage: boolean,
+  errors: ValidationErrors,
+): ImageAspectRatio {
+  if (raw) {
+    if (VALID_IMAGE_ASPECT_RATIOS.has(raw as ImageAspectRatio)) return raw as ImageAspectRatio;
+    errors.image_aspect_ratio = 'Must be vertical, square, horizontal, or none';
+  }
+  return classifyAspectRatio(width, height, hasImage);
+}
+
+function parseImageUrlFields(
+  imageUrl: string | null,
+  metadata: CreateEventBody,
+  errors: ValidationErrors,
+): ImageFields {
+  const validatedUrl = validateUrl(imageUrl, 'image_url', errors);
+  if (!validatedUrl) {
+    return {
+      imageUrl: null,
+      imageWidth: null,
+      imageHeight: null,
+      imageAspectRatio: 'none',
+      imageMimeType: null,
+      imageAltText: null,
+    };
+  }
+
+  const imageWidth = readIntegerField(metadata, ['image_width', 'imageWidth', 'width']);
+  const imageHeight = readIntegerField(metadata, ['image_height', 'imageHeight', 'height']);
+  const imageMimeType = parseOptionalString(
+    metadata,
+    ['image_mime_type', 'imageMimeType', 'mime_type', 'mimeType'],
+    'image_mime_type',
+    100,
+    errors,
+  );
+  const imageAltText = parseOptionalString(
+    metadata,
+    ['image_alt_text', 'imageAltText', 'alt_text', 'altText'],
+    'image_alt_text',
+    250,
+    errors,
+  );
+  const imageAspectRatio = normalizeAspectRatio(
+    readStringField(metadata, ['image_aspect_ratio', 'imageAspectRatio', 'aspect_ratio', 'aspectRatio']),
+    imageWidth,
+    imageHeight,
+    true,
+    errors,
+  );
+
+  return {
+    imageUrl: validatedUrl,
+    imageWidth,
+    imageHeight,
+    imageAspectRatio,
+    imageMimeType,
+    imageAltText,
+  };
+}
+
+function parseDataImage(input: string, fallbackMimeType: string | null): {
+  bytes: Uint8Array;
+  mimeType: string;
+} | null {
+  const dataUriMatch = input.match(/^data:([^;,]+);base64,(.+)$/);
+  const mimeType = dataUriMatch?.[1] ?? fallbackMimeType;
+  const base64 = dataUriMatch?.[2] ?? input;
+  if (!mimeType) return null;
+
+  try {
+    const binary = atob(base64.replace(/\s+/g, ''));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return { bytes, mimeType };
+  } catch {
+    return null;
+  }
+}
+
+function extensionForMimeType(mimeType: string, filename: string | null): string {
+  if (mimeType === 'image/jpeg') return 'jpg';
+  if (mimeType === 'image/png') return 'png';
+  if (mimeType === 'image/gif') return 'gif';
+  if (mimeType === 'image/webp') return 'webp';
+  const filenameMatch = filename?.match(/\.([a-z0-9]+)$/i);
+  return filenameMatch?.[1].toLowerCase() ?? 'bin';
+}
+
+async function storeImageBytes(
+  env: Env,
+  userId: number,
+  bytes: Uint8Array,
+  mimeType: string,
+  filename: string | null,
+  altText: string | null,
+  errors: ValidationErrors,
+): Promise<ImageFields> {
+  if (!ALLOWED_IMAGE_MIME_TYPES.has(mimeType)) {
+    errors.image = 'Must be a JPEG, PNG, GIF, or WebP image';
+  } else if (bytes.byteLength > MAX_IMAGE_BYTES) {
+    errors.image = 'Must be 5 MB or smaller';
+  } else if (!env.EVENT_IMAGES) {
+    errors.image = 'Image upload storage is not configured';
+  } else if (!env.EVENT_IMAGE_PUBLIC_BASE_URL) {
+    errors.image = 'Image public URL base is not configured';
+  }
+
+  if (errors.image) {
+    return {
+      imageUrl: null,
+      imageWidth: null,
+      imageHeight: null,
+      imageAspectRatio: 'none',
+      imageMimeType: null,
+      imageAltText: null,
+    };
+  }
+
+  const extension = extensionForMimeType(mimeType, filename);
+  const key = `events/user-created/${userId}/${crypto.randomUUID()}.${extension}`;
+  await env.EVENT_IMAGES!.put(key, bytes, {
+    httpMetadata: { contentType: mimeType },
+    customMetadata: { createdByUserId: String(userId) },
+  });
+
+  const dimensions = parseImageDimensions(bytes);
+  const imageWidth = dimensions?.width ?? null;
+  const imageHeight = dimensions?.height ?? null;
+  const publicBaseUrl = env.EVENT_IMAGE_PUBLIC_BASE_URL!.replace(/\/+$/g, '');
+
+  return {
+    imageUrl: `${publicBaseUrl}/${key}`,
+    imageWidth,
+    imageHeight,
+    imageAspectRatio: classifyAspectRatio(imageWidth, imageHeight, true, 0.05),
+    imageMimeType: mimeType,
+    imageAltText: altText,
+  };
+}
+
+function isFileLike(value: FormDataEntryValue): value is File {
+  return typeof File !== 'undefined' && value instanceof File;
+}
+
+function assignFormField(body: CreateEventBody, key: string, value: string): void {
+  if (key === 'categories' || key === 'interestTags' || key === 'interest_tags') {
+    try {
+      body[key] = JSON.parse(value);
+      return;
+    } catch {
+      body[key] = value
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean);
+      return;
+    }
+  }
+  body[key] = value;
+}
+
+async function readCreateEventBody(request: Request): Promise<{
+  body: CreateEventBody | null;
+  uploadedImage: File | null;
+  malformed: boolean;
+}> {
+  const contentType = request.headers.get('Content-Type') ?? '';
+  if (contentType.includes('multipart/form-data')) {
+    const form = await request.formData().catch(() => null);
+    if (!form) return { body: null, uploadedImage: null, malformed: true };
+
+    const body: CreateEventBody = {};
+    let uploadedImage: File | null = null;
+    for (const [key, value] of form.entries()) {
+      if (isFileLike(value)) {
+        if (key === 'image' && value.size > 0) uploadedImage = value;
+      } else {
+        assignFormField(body, key, value);
+      }
+    }
+    return { body, uploadedImage, malformed: false };
+  }
+
+  const parsed = await request.json().catch(() => null);
+  if (!isRecord(parsed)) return { body: null, uploadedImage: null, malformed: true };
+  return { body: parsed, uploadedImage: null, malformed: false };
+}
+
+async function resolveImageFields(
+  env: Env,
+  userId: number,
+  body: CreateEventBody,
+  uploadedImage: File | null,
+  errors: ValidationErrors,
+): Promise<ImageFields> {
+  const empty: ImageFields = {
+    imageUrl: null,
+    imageWidth: null,
+    imageHeight: null,
+    imageAspectRatio: 'none',
+    imageMimeType: null,
+    imageAltText: null,
+  };
+
+  if (uploadedImage) {
+    const bytes = new Uint8Array(await uploadedImage.arrayBuffer());
+    const altText = parseOptionalString(
+      body,
+      ['image_alt_text', 'imageAltText', 'alt_text', 'altText'],
+      'image_alt_text',
+      250,
+      errors,
+    );
+    if (Object.keys(errors).length > 0) return empty;
+    return storeImageBytes(
+      env,
+      userId,
+      bytes,
+      uploadedImage.type || 'application/octet-stream',
+      uploadedImage.name,
+      altText,
+      errors,
+    );
+  }
+
+  const image = body.image;
+  if (isRecord(image)) {
+    const imageUrl = readStringField(image, ['url', 'image_url', 'imageUrl']);
+    if (imageUrl) return parseImageUrlFields(imageUrl, image, errors);
+
+    const imageData = readStringField(image, ['data', 'base64', 'base64_data', 'base64Data']);
+    if (imageData) {
+      const parsed = parseDataImage(
+        imageData,
+        readStringField(image, ['mime_type', 'mimeType', 'image_mime_type', 'imageMimeType']),
+      );
+      if (!parsed) {
+        errors.image = 'Must include valid base64 image data and a MIME type';
+        return empty;
+      }
+      return storeImageBytes(
+        env,
+        userId,
+        parsed.bytes,
+        parsed.mimeType,
+        readStringField(image, ['filename', 'fileName', 'name']),
+        readStringField(image, ['alt_text', 'altText', 'image_alt_text', 'imageAltText']),
+        errors,
+      );
+    }
+  }
+
+  if (typeof image === 'string') {
+    const imageString = image.trim();
+    if (imageString.length > 0) {
+      if (imageString.startsWith('data:')) {
+        const parsed = parseDataImage(imageString, readStringField(body, ['image_mime_type', 'imageMimeType']));
+        if (!parsed) {
+          errors.image = 'Must include valid base64 image data and a MIME type';
+          return empty;
+        }
+        return storeImageBytes(env, userId, parsed.bytes, parsed.mimeType, null, null, errors);
+      }
+      return parseImageUrlFields(imageString, body, errors);
+    }
+  }
+
+  const imageBase64 = readStringField(body, ['image_base64', 'imageBase64']);
+  if (imageBase64) {
+    const parsed = parseDataImage(imageBase64, readStringField(body, ['image_mime_type', 'imageMimeType']));
+    if (!parsed) {
+      errors.image = 'Must include valid base64 image data and a MIME type';
+      return empty;
+    }
+    return storeImageBytes(env, userId, parsed.bytes, parsed.mimeType, null, null, errors);
+  }
+
+  const imageUrl = readStringField(body, ['image_url', 'imageUrl']);
+  if (imageUrl) return parseImageUrlFields(imageUrl, body, errors);
+
+  return empty;
+}
+
+function getHostName(body: CreateEventBody, user: AuthDbUser): string {
+  const poster = body.poster;
+  if (isRecord(poster)) {
+    const posterName = readStringField(poster, ['name']);
+    if (posterName) return posterName;
+  }
+
+  const name = [user.first_name, user.last_name]
+    .map((part) => (typeof part === 'string' ? part.trim() : ''))
+    .filter(Boolean)
+    .join(' ');
+  return name || user.email;
+}
+
+async function getCreatedEvent(db: D1Database, eventId: number): Promise<Record<string, unknown> | null> {
+  const event = await db
+    .prepare(
+      `SELECT e.*, o.profile_picture as org_profile_picture
+       FROM events e
+       LEFT JOIN organizations o ON e.host_organization_id = o.id
+       WHERE e.id = ?`,
+    )
+    .bind(eventId)
+    .first();
+
+  if (!event) return null;
+
+  const categories = await db
+    .prepare('SELECT category_id, category_name FROM event_categories WHERE event_id = ?')
+    .bind(eventId)
+    .all();
+
+  const benefits = await db
+    .prepare('SELECT benefit_name FROM event_benefits WHERE event_id = ?')
+    .bind(eventId)
+    .all();
+
+  return {
+    ...event,
+    categories: categories.results.map((category: any) => ({
+      id: category.category_id,
+      name: category.category_name,
+    })),
+    benefits: benefits.results.map((benefit: any) => benefit.benefit_name),
+  };
+}
+
 // Returns a SQL fragment + params that hide events the caller already
 // reported and any event over the global threshold.
 function buildVisibilityFilter(userId: number | null): {
@@ -68,6 +712,165 @@ function buildVisibilityFilter(userId: number | null): {
   }
   return { sql, params };
 }
+
+// POST /events/create -- authenticated users create their own events.
+eventRoutes.post('/create', async (c) => {
+  const hasAuthHeader = !!c.req.header('Authorization');
+  const user = await getCreateEventUser(c);
+  if (!user) {
+    return c.json({ error: hasAuthHeader ? 'USER_NOT_FOUND' : 'UNAUTHORIZED' }, 401);
+  }
+
+  const { body, uploadedImage, malformed } = await readCreateEventBody(c.req.raw);
+  if (malformed || !body) return c.json({ error: 'INVALID_BODY' }, 400);
+
+  const errors: ValidationErrors = {};
+  const title = parseRequiredString(
+    body,
+    ['title'],
+    'title',
+    MAX_TITLE_LENGTH,
+    errors,
+  );
+  const description = parseOptionalString(
+    body,
+    ['description'],
+    'description',
+    MAX_DESCRIPTION_LENGTH,
+    errors,
+  );
+  const startDatetime = parseIsoDatetime(
+    readStringField(body, ['start_datetime', 'startDatetime', 'datetime']),
+    'start_datetime',
+    true,
+    errors,
+  );
+  const rawEndDatetime = parseIsoDatetime(
+    readStringField(body, ['end_datetime', 'endDatetime']),
+    'end_datetime',
+    false,
+    errors,
+  );
+  const endDatetime = rawEndDatetime ?? startDatetime;
+
+  if (startDatetime && endDatetime && new Date(endDatetime).getTime() < new Date(startDatetime).getTime()) {
+    errors.end_datetime = 'Must be on or after start_datetime';
+  }
+
+  const locationObject = isRecord(body.location) ? body.location : null;
+  const locationFull =
+    parseOptionalString(body, ['location_full', 'locationFull'], 'location_full', MAX_LOCATION_LENGTH, errors) ??
+    parseOptionalString(
+      locationObject ?? {},
+      ['full', 'full_name', 'fullName', 'name'],
+      'location_full',
+      MAX_LOCATION_LENGTH,
+      errors,
+    ) ??
+    parseOptionalString(body, ['location'], 'location', MAX_LOCATION_LENGTH, errors);
+  const locationShort =
+    parseOptionalString(body, ['location_short', 'locationShort'], 'location_short', 40, errors) ??
+    parseOptionalString(locationObject ?? {}, ['short', 'short_name', 'shortName'], 'location_short', 40, errors) ??
+    truncateLocation(locationFull);
+  const rsvpUrl = validateUrl(
+    readStringField(body, ['rsvp_url', 'rsvpUrl']),
+    'rsvp_url',
+    errors,
+  );
+  const eventUrl = validateUrl(
+    readStringField(body, ['event_url', 'eventUrl']),
+    'event_url',
+    errors,
+  );
+  const theme =
+    parseOptionalString(body, ['theme'], 'theme', 80, errors) ??
+    (() => {
+      const discoveryBucket = readStringField(body, ['discovery_bucket', 'discoveryBucket']);
+      return discoveryBucket ? THEME_BY_DISCOVERY_BUCKET[discoveryBucket] ?? null : null;
+    })();
+  const latitude = readNumberField(body, ['latitude', 'lat']);
+  const longitude = readNumberField(body, ['longitude', 'lng', 'lon']);
+  const categories = normalizeCategories(body, errors);
+  const imageFields =
+    Object.keys(errors).length === 0
+      ? await resolveImageFields(c.env, user.id, body, uploadedImage, errors)
+      : {
+          imageUrl: null,
+          imageWidth: null,
+          imageHeight: null,
+          imageAspectRatio: 'none' as ImageAspectRatio,
+          imageMimeType: null,
+          imageAltText: null,
+        };
+
+  if (Object.keys(errors).length > 0 || !title || !startDatetime || !endDatetime) {
+    return c.json({ error: 'VALIDATION_ERROR', fields: errors }, 400);
+  }
+
+  const sourceEventId = `user-${user.id}-${crypto.randomUUID()}`;
+  const hostName = getHostName(body, user);
+  const expiresAt = computeExpiresAt(endDatetime, startDatetime);
+
+  const result = await c.env.DB.prepare(
+    `INSERT INTO events (
+       source, source_event_id, title, description,
+       start_datetime, end_datetime, location_short, location_full,
+       latitude, longitude, host_organization_name,
+       event_url, rsvp_url,
+       image_url, image_width, image_height,
+       image_aspect_ratio, image_mime_type, image_alt_text,
+       theme, visibility, rsvp_total, expires_at,
+       created_by_user_id
+     ) VALUES (
+       ?, ?, ?, ?,
+       ?, ?, ?, ?,
+       ?, ?, ?,
+       ?, ?,
+       ?, ?, ?,
+       ?, ?, ?,
+       ?, 'Public', 0, ?,
+       ?
+     )`,
+  )
+    .bind(
+      USER_CREATED_SOURCE,
+      sourceEventId,
+      title,
+      description,
+      startDatetime,
+      endDatetime,
+      locationShort,
+      locationFull,
+      latitude,
+      longitude,
+      hostName,
+      eventUrl,
+      rsvpUrl,
+      imageFields.imageUrl,
+      imageFields.imageWidth,
+      imageFields.imageHeight,
+      imageFields.imageAspectRatio,
+      imageFields.imageMimeType,
+      imageFields.imageAltText,
+      theme,
+      expiresAt,
+      user.id,
+    )
+    .run();
+
+  const eventId = Number((result.meta as { last_row_id?: number }).last_row_id);
+  for (const category of categories) {
+    await c.env.DB.prepare(
+      `INSERT OR IGNORE INTO event_categories (event_id, category_id, category_name)
+       VALUES (?, ?, ?)`,
+    )
+      .bind(eventId, category.id, category.name)
+      .run();
+  }
+
+  const event = await getCreatedEvent(c.env.DB, eventId);
+  return c.json({ event }, 201);
+});
 
 // GET /events -- list upcoming events with optional filters
 eventRoutes.get('/', async (c) => {

--- a/server/src/worker.ts
+++ b/server/src/worker.ts
@@ -10,12 +10,17 @@ import { SCRAPERS } from './scrapers/registry';
 
 export type Env = {
   DB: D1Database;
+  EVENT_IMAGES?: R2Bucket;
+  EVENT_IMAGE_PUBLIC_BASE_URL?: string;
   JWT_SECRET: string;
   RESEND_API_KEY: string;
   // When set to "true" in .dev.vars, the Worker logs verification codes to
   // the wrangler console instead of sending them through Resend. Never set
   // in production.
   RESEND_DEV_MODE?: string;
+  // Local/remote dev only: lets the create-event UI be tested from the
+  // dev skip-to-home path, which has no JWT token.
+  DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE?: string;
 };
 
 const app = new Hono<{ Bindings: Env }>();

--- a/server/src/worker.ts
+++ b/server/src/worker.ts
@@ -18,9 +18,6 @@ export type Env = {
   // the wrangler console instead of sending them through Resend. Never set
   // in production.
   RESEND_DEV_MODE?: string;
-  // Local/remote dev only: lets the create-event UI be tested from the
-  // dev skip-to-home path, which has no JWT token.
-  DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE?: string;
 };
 
 const app = new Hono<{ Bindings: Env }>();

--- a/server/test/routes/test_events_create.ts
+++ b/server/test/routes/test_events_create.ts
@@ -1,0 +1,372 @@
+import { describe, expect, it } from 'vitest';
+import { eventRoutes } from '../../src/routes/events.worker';
+import type { Env } from '../../src/worker';
+
+const JWT_SECRET = 'test-secret';
+const USER_EMAIL = 'student@utexas.edu';
+const PNG_1X1_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=';
+
+type UserRow = {
+  id: number;
+  email: string;
+  first_name: string;
+  last_name: string;
+};
+
+type EventRow = Record<string, unknown> & {
+  id: number;
+  source: string;
+  source_event_id: string;
+  title: string;
+  start_datetime: string;
+  end_datetime: string;
+  created_by_user_id: number;
+};
+
+class FakeD1Statement {
+  private params: unknown[] = [];
+
+  constructor(
+    private readonly db: FakeD1Database,
+    private readonly sql: string,
+  ) {}
+
+  bind(...params: unknown[]): FakeD1Statement {
+    this.params = params;
+    return this;
+  }
+
+  async first(): Promise<Record<string, unknown> | null> {
+    return this.db.first(this.sql, this.params);
+  }
+
+  async all(): Promise<{ results: Record<string, unknown>[] }> {
+    return { results: this.db.all(this.sql, this.params) };
+  }
+
+  async run(): Promise<{ meta: { last_row_id?: number } }> {
+    return this.db.run(this.sql, this.params);
+  }
+}
+
+class FakeD1Database {
+  readonly events: EventRow[] = [];
+  readonly eventCategories: { event_id: number; category_id: string; category_name: string | null }[] =
+    [];
+
+  constructor(
+    private readonly users: UserRow[] = [
+      { id: 1, email: USER_EMAIL, first_name: 'Bevo', last_name: 'Student' },
+    ],
+  ) {}
+
+  prepare(sql: string): FakeD1Statement {
+    return new FakeD1Statement(this, sql);
+  }
+
+  first(sql: string, params: unknown[]): Record<string, unknown> | null {
+    if (sql.includes('FROM users WHERE email = ?')) {
+      return this.users.find((user) => user.email === params[0]) ?? null;
+    }
+
+    if (sql.includes('FROM events e') && sql.includes('WHERE e.id = ?')) {
+      const event = this.events.find((row) => row.id === params[0]);
+      return event ? { ...event, org_profile_picture: null } : null;
+    }
+
+    throw new Error(`Unexpected first() SQL: ${sql}`);
+  }
+
+  all(sql: string, params: unknown[]): Record<string, unknown>[] {
+    if (sql.includes('FROM event_categories WHERE event_id = ?')) {
+      return this.eventCategories
+        .filter((category) => category.event_id === params[0])
+        .map((category) => ({
+          category_id: category.category_id,
+          category_name: category.category_name,
+        }));
+    }
+
+    if (sql.includes('FROM event_benefits WHERE event_id = ?')) {
+      return [];
+    }
+
+    throw new Error(`Unexpected all() SQL: ${sql}`);
+  }
+
+  run(sql: string, params: unknown[]): { meta: { last_row_id?: number } } {
+    if (sql.includes('INSERT INTO users')) {
+      const email = params[0] as string;
+      const existing = this.users.find((user) => user.email === email);
+      if (existing) {
+        existing.first_name = 'Dev';
+        existing.last_name = 'User';
+        return { meta: { last_row_id: existing.id } };
+      }
+
+      const nextId = Math.max(0, ...this.users.map((user) => user.id)) + 1;
+      this.users.push({
+        id: nextId,
+        email,
+        first_name: 'Dev',
+        last_name: 'User',
+      });
+      return { meta: { last_row_id: nextId } };
+    }
+
+    if (sql.includes('INSERT INTO events')) {
+      const id = this.events.length + 1;
+      const event: EventRow = {
+        id,
+        source: params[0] as string,
+        source_event_id: params[1] as string,
+        title: params[2] as string,
+        description: params[3] as string | null,
+        start_datetime: params[4] as string,
+        end_datetime: params[5] as string,
+        location_short: params[6] as string | null,
+        location_full: params[7] as string | null,
+        latitude: params[8] as number | null,
+        longitude: params[9] as number | null,
+        host_organization_id: null,
+        host_organization_name: params[10] as string,
+        event_url: params[11] as string | null,
+        rsvp_url: params[12] as string | null,
+        image_url: params[13] as string | null,
+        image_width: params[14] as number | null,
+        image_height: params[15] as number | null,
+        image_aspect_ratio: params[16] as string,
+        image_mime_type: params[17] as string | null,
+        image_alt_text: params[18] as string | null,
+        theme: params[19] as string | null,
+        visibility: 'Public',
+        rsvp_total: 0,
+        status: 'active',
+        expires_at: params[20] as string,
+        is_featured: 0,
+        created_by_user_id: params[21] as number,
+        is_archived: 0,
+        archived_at: null,
+      };
+      this.events.push(event);
+      return { meta: { last_row_id: id } };
+    }
+
+    if (sql.includes('INSERT OR IGNORE INTO event_categories')) {
+      const row = {
+        event_id: params[0] as number,
+        category_id: params[1] as string,
+        category_name: params[2] as string | null,
+      };
+      if (
+        !this.eventCategories.some(
+          (category) =>
+            category.event_id === row.event_id && category.category_id === row.category_id,
+        )
+      ) {
+        this.eventCategories.push(row);
+      }
+      return { meta: {} };
+    }
+
+    throw new Error(`Unexpected run() SQL: ${sql}`);
+  }
+}
+
+class FakeR2Bucket {
+  readonly puts: { key: string; value: unknown; options: unknown }[] = [];
+
+  async put(key: string, value: unknown, options: unknown): Promise<null> {
+    this.puts.push({ key, value, options });
+    return null;
+  }
+}
+
+function makeEnv(
+  db: FakeD1Database,
+  imageBucket?: FakeR2Bucket,
+  overrides: Partial<Env> = {},
+): Env {
+  return {
+    DB: db as unknown as D1Database,
+    EVENT_IMAGES: imageBucket as unknown as R2Bucket,
+    EVENT_IMAGE_PUBLIC_BASE_URL: imageBucket ? 'https://cdn.example.test' : undefined,
+    JWT_SECRET,
+    RESEND_API_KEY: '',
+    ...overrides,
+  };
+}
+
+async function signJwt(email: string): Promise<string> {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const payload = {
+    email,
+    iat: Math.floor(Date.now() / 1000),
+    exp: Math.floor(Date.now() / 1000) + 60,
+  };
+
+  const headerB64 = btoa(JSON.stringify(header)).replace(/=/g, '');
+  const payloadB64 = btoa(JSON.stringify(payload)).replace(/=/g, '');
+  const signingInput = `${headerB64}.${payloadB64}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(JWT_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(signingInput));
+  const sigB64 = btoa(String.fromCharCode(...new Uint8Array(signature))).replace(/=/g, '');
+  return `${signingInput}.${sigB64}`;
+}
+
+async function postCreate(
+  env: Env,
+  body: Record<string, unknown>,
+  token?: string,
+): Promise<Response> {
+  return eventRoutes.request(
+    'http://longhorn-loop.test/create',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(body),
+    },
+    env,
+  );
+}
+
+describe('POST /events/create', () => {
+  it('creates a user-created event for an authenticated user', async () => {
+    const db = new FakeD1Database();
+    const token = await signJwt(USER_EMAIL);
+
+    const res = await postCreate(
+      makeEnv(db),
+      {
+        title: 'Board Game Night',
+        description: 'Bring a friend and a favorite game.',
+        start_datetime: '2026-07-07T19:00:00-05:00',
+        location: 'GDC 2.216',
+        rsvp_url: 'https://example.test/rsvp',
+        discoveryBucket: 'gaming',
+        categories: [{ id: 'gaming', name: 'Gaming' }, 'Board Games & Tabletop'],
+      },
+      token,
+    );
+
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { event: EventRow & { categories: unknown[] } };
+    expect(json.event).toMatchObject({
+      source: 'user_created',
+      title: 'Board Game Night',
+      start_datetime: '2026-07-08T00:00:00.000Z',
+      end_datetime: '2026-07-08T00:00:00.000Z',
+      location_short: 'GDC 2.216',
+      location_full: 'GDC 2.216',
+      host_organization_name: 'Bevo Student',
+      rsvp_url: 'https://example.test/rsvp',
+      theme: 'Social',
+      created_by_user_id: 1,
+      image_url: null,
+      image_aspect_ratio: 'none',
+    });
+    expect(json.event.source_event_id).toMatch(/^user-1-/);
+    expect(json.event.categories).toEqual([
+      { id: 'gaming', name: 'Gaming' },
+      { id: 'board-games-and-tabletop', name: 'Board Games & Tabletop' },
+    ]);
+    expect(db.events).toHaveLength(1);
+  });
+
+  it('returns validation errors when a required field is missing', async () => {
+    const db = new FakeD1Database();
+    const token = await signJwt(USER_EMAIL);
+
+    const res = await postCreate(
+      makeEnv(db),
+      { start_datetime: '2026-07-07T19:00:00-05:00' },
+      token,
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: 'VALIDATION_ERROR',
+      fields: { title: 'Required' },
+    });
+    expect(db.events).toHaveLength(0);
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    const db = new FakeD1Database();
+
+    const res = await postCreate(makeEnv(db), {
+      title: 'Unauthorized Event',
+      start_datetime: '2026-07-07T19:00:00-05:00',
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'UNAUTHORIZED' });
+    expect(db.events).toHaveLength(0);
+  });
+
+  it('allows unauthenticated creates only when the dev bypass flag is enabled', async () => {
+    const db = new FakeD1Database([]);
+
+    const res = await postCreate(
+      makeEnv(db, undefined, { DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE: 'true' }),
+      {
+        title: 'Dev Skip Event',
+        start_datetime: '2026-07-07T19:00:00-05:00',
+      },
+    );
+
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { event: EventRow };
+    expect(json.event).toMatchObject({
+      title: 'Dev Skip Event',
+      host_organization_name: 'Dev User',
+      created_by_user_id: 1,
+    });
+    expect(json.event.source_event_id).toMatch(/^user-1-/);
+    expect(db.events).toHaveLength(1);
+  });
+
+  it('stores an uploaded base64 image when R2 is configured', async () => {
+    const db = new FakeD1Database();
+    const bucket = new FakeR2Bucket();
+    const token = await signJwt(USER_EMAIL);
+
+    const res = await postCreate(
+      makeEnv(db, bucket),
+      {
+        title: 'Flyer Event',
+        startDatetime: '2026-07-07T19:00:00-05:00',
+        image: {
+          data: `data:image/png;base64,${PNG_1X1_BASE64}`,
+          filename: 'flyer.png',
+          altText: 'Flyer',
+        },
+      },
+      token,
+    );
+
+    expect(res.status).toBe(201);
+    expect(bucket.puts).toHaveLength(1);
+    expect(bucket.puts[0].key).toMatch(/^events\/user-created\/1\/.+\.png$/);
+
+    const json = (await res.json()) as { event: EventRow };
+    expect(json.event).toMatchObject({
+      image_url: `https://cdn.example.test/${bucket.puts[0].key}`,
+      image_width: 1,
+      image_height: 1,
+      image_aspect_ratio: 'square',
+      image_mime_type: 'image/png',
+      image_alt_text: 'Flyer',
+    });
+  });
+});

--- a/server/test/routes/test_events_create.ts
+++ b/server/test/routes/test_events_create.ts
@@ -52,8 +52,11 @@ class FakeD1Statement {
 
 class FakeD1Database {
   readonly events: EventRow[] = [];
-  readonly eventCategories: { event_id: number; category_id: string; category_name: string | null }[] =
-    [];
+  readonly eventCategories: {
+    event_id: number;
+    category_id: string;
+    category_name: string | null;
+  }[] = [];
 
   constructor(
     private readonly users: UserRow[] = [
@@ -96,25 +99,6 @@ class FakeD1Database {
   }
 
   run(sql: string, params: unknown[]): { meta: { last_row_id?: number } } {
-    if (sql.includes('INSERT INTO users')) {
-      const email = params[0] as string;
-      const existing = this.users.find((user) => user.email === email);
-      if (existing) {
-        existing.first_name = 'Dev';
-        existing.last_name = 'User';
-        return { meta: { last_row_id: existing.id } };
-      }
-
-      const nextId = Math.max(0, ...this.users.map((user) => user.id)) + 1;
-      this.users.push({
-        id: nextId,
-        email,
-        first_name: 'Dev',
-        last_name: 'User',
-      });
-      return { meta: { last_row_id: nextId } };
-    }
-
     if (sql.includes('INSERT INTO events')) {
       const id = this.events.length + 1;
       const event: EventRow = {
@@ -312,28 +296,6 @@ describe('POST /events/create', () => {
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: 'UNAUTHORIZED' });
     expect(db.events).toHaveLength(0);
-  });
-
-  it('allows unauthenticated creates only when the dev bypass flag is enabled', async () => {
-    const db = new FakeD1Database([]);
-
-    const res = await postCreate(
-      makeEnv(db, undefined, { DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE: 'true' }),
-      {
-        title: 'Dev Skip Event',
-        start_datetime: '2026-07-07T19:00:00-05:00',
-      },
-    );
-
-    expect(res.status).toBe(201);
-    const json = (await res.json()) as { event: EventRow };
-    expect(json.event).toMatchObject({
-      title: 'Dev Skip Event',
-      host_organization_name: 'Dev User',
-      created_by_user_id: 1,
-    });
-    expect(json.event.source_event_id).toMatch(/^user-1-/);
-    expect(db.events).toHaveLength(1);
   });
 
   it('stores an uploaded base64 image when R2 is configured', async () => {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,5 +9,6 @@
     "skipLibCheck": true,
     "types": ["@cloudflare/workers-types"]
   },
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "vitest.config.ts"]
 }

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -7,6 +7,10 @@ binding = "DB"
 database_name = "loop-db"
 database_id = "dc2be36a-b3b9-45a5-9fc8-fb223eb336bf"
 
+[[r2_buckets]]
+binding = "EVENT_IMAGES"
+bucket_name = "longhorn-loop-event-images"
+
 [triggers]
 # Both schedules fire the same scheduled() handler in worker.ts, which
 # dispatches on event.cron:
@@ -17,3 +21,6 @@ crons = ["0 */6 * * *", "*/15 * * * *"]
 
 # Set your JWT secret as a Workers secret (not in this file):
 #   wrangler secret put JWT_SECRET
+
+[vars]
+EVENT_IMAGE_PUBLIC_BASE_URL = "https://pub-1fa687f6640643bc900bbbc25e3aba0c.r2.dev"


### PR DESCRIPTION
Title: LOOP-151: Add authenticated user-created event endpoint with R2 image uploads

## Summary

Implements LOOP-151: authenticated users can create events through `POST /events/create`, including required-field validation, category mapping, optional image upload to Cloudflare R2, and frontend Create Event flow wiring.

This also adds a temporary local/dev-only unauthenticated bypass so the Create Event flow can be tested from the current dev skip-to-home path without signing in.

## What Changed

### Backend

- Added `POST /events/create` in the Worker.
- Validates JWT auth from the existing auth flow.
- Rejects unauthenticated requests with `401` unless the dev bypass flag is explicitly enabled.
- Requires:
  - `title`
  - `start_datetime`
- Validates:
  - ISO 8601 datetime with timezone
  - field lengths
  - optional URLs
  - category shape/count
  - image MIME type and file size
- Inserts new rows into `events` with:
  - `source = 'user_created'`
  - `created_by_user_id = authenticated user id`
  - `expires_at`
  - normalized image metadata
- Maps submitted categories into `event_categories`.
- Supports JSON and multipart form submissions.
- Supports optional image upload through Cloudflare R2.
- Added test coverage for:
  - valid create
  - missing required field
  - unauthenticated rejection
  - dev bypass create
  - image upload path

### Cloudflare R2

Configured the Worker to use this R2 bucket:

[[r2_buckets]]
binding = "EVENT_IMAGES"
bucket_name = "longhorn-loop-event-images"

Uploaded event images are stored under:

events/user-created/{userId}/{uuid}.{ext}

The public image URL is built from:

EVENT_IMAGE_PUBLIC_BASE_URL

Current test bucket public URL used locally:

EVENT_IMAGE_PUBLIC_BASE_URL=https://pub-1fa687f6640643bc900bbbc25e3aba0c.r2.dev

### Frontend

- Wired the final Create Event step to call `POST /events/create`.
- Added multipart `FormData` submission support to the API client.
- Sends:
  - title
  - description
  - start/end datetime
  - location
  - RSVP URL
  - discovery bucket
  - event type
  - categories
  - optional image
- Invalidates event/explore queries after successful create.
- Redirects home with the existing success modal param.
- Fixed web image upload by converting selected image URIs to real browser `Blob`s before appending to `FormData`.
- Native upload still uses the React Native `{ uri, name, type }` file shape.

## Local Setup / Env Vars Needed

In `server/.dev.vars`, local testing needs the existing auth/database vars plus:

EVENT_IMAGE_PUBLIC_BASE_URL=https://pub-1fa687f6640643bc900bbbc25e3aba0c.r2.dev

# Local testing only. Do not enable in production.
DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE=true

Notes:

- `EVENT_IMAGE_PUBLIC_BASE_URL` is not a secret, but it is required for uploaded images to resolve publicly.
- `DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE=true` allows testing Create Event after using the dev skip-to-home button.
- Production should omit this flag or set it to `false`.

## How To Test Locally

Start the Worker against remote Cloudflare resources:

cd server
npx wrangler dev --remote --port 8787

Start the frontend:

npm start

Then:

1. Open the app locally.
2. Use the dev skip-to-home path if testing without auth.
3. Go through Create Event.
4. Add title and date/time.
5. Optionally upload an image.
6. Press Post Event.
7. Confirm the success modal appears on Home.
8. Confirm the row exists in D1.
9. Confirm the image exists in R2 if one was uploaded.

Useful checks:

cd server
npx wrangler d1 execute loop-db --remote --command "SELECT id, title, source, created_by_user_id, image_url FROM events WHERE source = 'user_created' ORDER BY id DESC LIMIT 5;"

cd server
npx wrangler r2 object list longhorn-loop-event-images --remote --prefix events/user-created/

Important: `wrangler dev --remote` writes to real remote D1/R2 resources, so test rows/images should be cleaned up after manual testing.

## Verification

Passed:

npm run typecheck

cd server
npm run build

cd server
npm test

Server tests passed:

35 passed

Manual end-to-end testing was also performed with:

- frontend running locally
- Worker running via `wrangler dev --remote`
- real D1 insert
- real R2 image upload
- public R2 image URL verified
- test D1 row and R2 object cleaned up afterward

## Production Notes / Caveats

- Production Worker must have the `EVENT_IMAGES` R2 binding configured.
- Production Worker must have `EVENT_IMAGE_PUBLIC_BASE_URL` configured.
- `DEV_ALLOW_UNAUTHENTICATED_EVENT_CREATE` must not be enabled in production.
- This depends on the `created_by_user_id` column from LOOP-148.
- The frontend still has a dev skip-to-home path that does not create a real auth token; that is why the temporary dev bypass exists.
- `Preview Event` is still a placeholder/no-op and is not part of this backend issue.
- The current create flow posts as the authenticated user/dev user. It does not yet support real organization posting from the hardcoded “Who’s Posting” UI.
- Future cleanup should remove the unauthenticated dev bypass once local auth testing is easier or the dev skip path creates a usable token.