### PR TITLE
feat(server): Add UT Law scraper and unify manual scrape routes

### DIFF
--- a/server/src/routes/events.worker.ts
+++ b/server/src/routes/events.worker.ts
@@ -1081,4 +1081,3 @@ eventRoutes.post('/scrape/:name', async (c) => {
 
   return c.json(result);
 });
-

--- a/server/src/routes/events.worker.ts
+++ b/server/src/routes/events.worker.ts
@@ -2,8 +2,7 @@
 import { Hono } from 'hono';
 import { classifyAspectRatio, parseImageDimensions } from '../events/normalize';
 import type { ImageAspectRatio } from '../events/types';
-import { scrapeHornsLink } from '../scrapers/hornslink';
-import { scrapeMccombs } from '../scrapers/mccombs';
+import { getManualScraper, SCRAPERS } from '../scrapers/registry';
 import type { Env } from '../worker';
 
 export const eventRoutes = new Hono<{ Bindings: Env }>();
@@ -864,6 +863,7 @@ eventRoutes.get('/', async (c) => {
   const benefit = c.req.query('benefit');
   const theme = c.req.query('theme');
   const orgId = c.req.query('orgId');
+  const source = c.req.query('source');
 
   // If the caller is signed in, also hide events they've already reported.
   // Anonymous callers only get the global threshold filter.
@@ -890,6 +890,11 @@ eventRoutes.get('/', async (c) => {
   if (orgId) {
     query += ` AND e.host_organization_id = ?`;
     params.push(parseInt(orgId));
+  }
+
+  if (source) {
+    query += ` AND e.source = ?`;
+    params.push(source);
   }
 
   if (category) {
@@ -1061,24 +1066,19 @@ eventRoutes.post('/:id/report', async (c) => {
   return c.json({ ok: true });
 });
 
-// POST /events/scrape -- manually trigger a scrape (for testing)
-eventRoutes.post('/scrape', async (c) => {
-  const body = await c.req.json().catch(() => ({}));
-  const maxPages = (body as any).maxPages ?? 3;
-  const dryRun = (body as any).dryRun ?? false;
+// POST /events/scrape/:name -- manually trigger any registered scraper (for testing)
+eventRoutes.post('/scrape/:name', async (c) => {
+  const scraperName = c.req.param('name');
+  const scraper = getManualScraper(scraperName);
 
-  const result = await scrapeHornsLink(c.env.DB, { maxPages, dryRun });
+  if (!scraper) {
+    const available = SCRAPERS.filter((s) => s.manual).map((s) => s.name);
+    return c.json({ error: 'UNKNOWN_SCRAPER', available }, 404);
+  }
+
+  const body = await c.req.json().catch(() => ({}));
+  const result = await scraper(c.env.DB, body as Record<string, unknown>);
 
   return c.json(result);
 });
 
-// POST /events/scrape/mccombs -- manually trigger the McCombs scrape (for testing)
-eventRoutes.post('/scrape/mccombs', async (c) => {
-  const body = await c.req.json().catch(() => ({}));
-  const maxEvents = (body as any).maxEvents ?? 500;
-  const dryRun = (body as any).dryRun ?? false;
-
-  const result = await scrapeMccombs(c.env.DB, { maxEvents, dryRun });
-
-  return c.json(result);
-});

--- a/server/src/scrapers/__fixtures__/lawSchool/feed.ics
+++ b/server/src/scrapers/__fixtures__/lawSchool/feed.ics
@@ -1,0 +1,87 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//LiveWhale Calendar//NONSGML v1.0//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:Texas Law Events
+BEGIN:VTIMEZONE
+TZID:US/Central
+X-LIC-LOCATION:America/Chicago
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0600
+TZOFFSETTO:-0500
+TZNAME:CDT
+DTSTART:19700308T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0600
+TZNAME:CST
+DTSTART:19701101T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTART;VALUE=DATE-TIME;TZID=US/Central:20260727T113000
+DTEND;VALUE=DATE-TIME;TZID=US/Central:20260727T124500
+DTSTAMP:20260717T233000Z
+CREATED:20260520T163400Z
+LAST-MODIFIED:20260520T163400Z
+UID:20260727T113000-88639@law.utexas.edu
+SUMMARY:Drawing Board Luncheon: Avihay Dorfman
+DESCRIPTION:<p>Drawing Board Luncheon: Avihay Dorfman</p>If you need an
+  accommodation to participate in this event, please contact the event
+  sponsor or the Texas Law Special Events Office at
+  specialevents@law.utexas.edu no later than seven business days prior to
+  the event. Speaker: Avihay Dorfman, "The Friends of Joe Jamail" Regents
+  Chair in Law, Professor, University of Texas
+X-ALT-DESC;FMTTYPE=text/html:<p>Drawing Board Luncheon: Avihay
+  Dorfman</p>
+LOCATION:TNH 2.111 - Sheffield-Massey Room
+URL:https://law.utexas.edu/calendar/2026/07/27/88639/
+CLASS:PUBLIC
+STATUS:CONFIRMED
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;VALUE=DATE-TIME;TZID=US/Central:20260729T070000
+DTEND;VALUE=DATE-TIME;TZID=US/Central:20260729T083000
+DTSTAMP:20260717T233000Z
+CREATED:20260422T160000Z
+LAST-MODIFIED:20260623T162600Z
+UID:20260729T070000-88420@law.utexas.edu
+SUMMARY:Alumni Breakfast at NBA
+DESCRIPTION:<p>Join your fellow Texas Law alumni for breakfast at the
+  National Bar Association's Annual Convention and Exhibits. Start your
+  day by visiting with the Dean\, hearing about the latest from your alma
+  mater\, and connecting with old friends and new!</p>
+LOCATION:
+URL:https://law.utexas.edu/calendar/2026/07/29/88420/
+CLASS:PUBLIC
+STATUS:CONFIRMED
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;VALUE=DATE-TIME;TZID=US/Central:20270115T090000
+DTEND;VALUE=DATE-TIME;TZID=US/Central:20270115T100000
+DTSTAMP:20260717T233000Z
+UID:20270115T090000-90001@law.utexas.edu
+SUMMARY:Spring Semester Kickoff
+DESCRIPTION:Welcome back to a new semester at Texas Law.
+LOCATION:Eidman Courtroom
+URL:https://law.utexas.edu/calendar/2027/01/15/90001/
+CLASS:PUBLIC
+STATUS:CONFIRMED
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;VALUE=DATE-TIME;TZID=US/Central:20200310T120000
+DTEND;VALUE=DATE-TIME;TZID=US/Central:20200310T130000
+DTSTAMP:20200217T233000Z
+UID:20200310T120000-70000@law.utexas.edu
+SUMMARY:Past Event That Should Be Skipped
+DESCRIPTION:This event already happened.
+LOCATION:Old Hall
+URL:https://law.utexas.edu/calendar/2020/03/10/70000/
+CLASS:PUBLIC
+STATUS:CONFIRMED
+END:VEVENT
+END:VCALENDAR

--- a/server/src/scrapers/lawSchool.ts
+++ b/server/src/scrapers/lawSchool.ts
@@ -2,7 +2,7 @@
 //
 // LiveWhale has no JSON API,but does publish a
 // clean public iCal feed at /calendar/feed/ics/ covering ~1 year of
-// upcoming events. We fetch that single feed and parse the VEVENTs 
+// upcoming events. We fetch that single feed and parse the VEVENTs
 
 // iCal quirks we handle:
 //   - Lines are folded (RFC 5545): continuation lines start with a space

--- a/server/src/scrapers/lawSchool.ts
+++ b/server/src/scrapers/lawSchool.ts
@@ -1,0 +1,317 @@
+// UT Law School scraper: law.utexas.edu/calendar (LiveWhale).
+//
+// LiveWhale has no JSON API,but does publish a
+// clean public iCal feed at /calendar/feed/ics/ covering ~1 year of
+// upcoming events. We fetch that single feed and parse the VEVENTs 
+
+// iCal quirks we handle:
+//   - Lines are folded (RFC 5545): continuation lines start with a space
+//     or tab and must be joined back onto the previous line.
+//   - DTSTART/DTEND are local wall-clock times tagged TZID=US/Central with
+//     NO offset (e.g. 20260727T113000). We convert to a real instant using
+//     the America/Chicago zone so DST (CDT -05:00 vs CST -06:00) is correct.
+//   - Text values use iCal escaping (\n \, \; \\) which we unescape, and the
+//     DESCRIPTION body is HTML which we strip.
+//
+// Dedup key: the VEVENT UID (e.g. "20260727T113000-88639@law.utexas.edu"),
+// which is already unique per occurrence.
+
+import { ingestEvents } from '../events/ingest';
+import { stripHtml, truncateLocation } from '../events/normalize';
+import { fetchWithRetry } from '../events/polite-fetch';
+import type { NormalizedEvent } from '../events/types';
+import type { Env } from '../worker';
+
+const FEED_URL = 'https://law.utexas.edu/calendar/feed/ics/';
+export const SOURCE = 'ut_law';
+
+const DEFAULT_MAX_EVENTS = 500;
+const DEFAULT_ORG_NAME = 'The University of Texas School of Law';
+const CALENDAR_TZ = 'America/Chicago';
+
+interface ScraperResult {
+  eventsProcessed: number;
+  eventsUpserted: number;
+  eventsSkipped: number;
+  errors: string[];
+  durationMs: number;
+}
+
+// Helpers, exported for unit tests
+
+// RFC 5545 line folding: a CRLF (or LF) followed by a single space or tab
+// is a continuation of the previous line. Unfold before parsing properties.
+export function unfoldIcs(raw: string): string {
+  return raw.replace(/\r\n/g, '\n').replace(/\n[ \t]/g, '');
+}
+
+export function splitVevents(unfolded: string): string[] {
+  return [...unfolded.matchAll(/BEGIN:VEVENT\n([\s\S]*?)\nEND:VEVENT/g)].map((m) => m[1]);
+}
+
+// Reverse iCal TEXT escaping. Order matters: unescape "\\" last so an
+// escaped backslash doesn't get re-interpreted.
+export function unescapeIcsText(value: string): string {
+  return value
+    .replace(/\\n/gi, '\n')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+    .replace(/\\\\/g, '\\');
+}
+
+export interface IcsProperty {
+  params: Record<string, string>;
+  value: string;
+}
+
+// Parse a VEVENT block's "NAME;PARAM=x;PARAM=y:VALUE" lines into a map
+// keyed by property name. Only the first occurrence of each name is kept
+// (VEVENTs here don't repeat properties we care about).
+export function parseIcsProperties(block: string): Record<string, IcsProperty> {
+  const props: Record<string, IcsProperty> = {};
+  for (const line of block.split('\n')) {
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const namePart = line.slice(0, colon);
+    const value = line.slice(colon + 1);
+    const [name, ...paramParts] = namePart.split(';');
+    const key = name.toUpperCase();
+    if (props[key]) continue;
+    const params: Record<string, string> = {};
+    for (const p of paramParts) {
+      const eq = p.indexOf('=');
+      if (eq === -1) continue;
+      params[p.slice(0, eq).toUpperCase()] = p.slice(eq + 1);
+    }
+    props[key] = { params, value };
+  }
+  return props;
+}
+
+// Offset (in ms) of `timeZone` at the given UTC instant. Derived by
+// formatting the instant as wall-clock in the zone and diffing against the
+// instant itself
+function timeZoneOffsetMs(utcMs: number, timeZone: string): number {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  const parts = dtf.formatToParts(new Date(utcMs));
+  const map: Record<string, number> = {};
+  for (const part of parts) {
+    if (part.type !== 'literal') map[part.type] = Number(part.value);
+  }
+  // Intl formats hour "24" for midnight; normalize to 0.
+  const hour = map.hour === 24 ? 0 : map.hour;
+  const asIfUtc = Date.UTC(map.year, map.month - 1, map.day, hour, map.minute, map.second);
+  return asIfUtc - utcMs;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+// Convert an iCal date-time (e.g. "20260727T113000", or all-day
+// "20260727") that represents wall-clock time in `timeZone` into an ISO
+// 8601 string carrying the correct numeric offset. Returns null if the
+// value can't be parsed.
+export function icsDateToIso(value: string, timeZone: string = CALENDAR_TZ): string | null {
+  // A trailing Z means it's already UTC; pass it straight through as an offset.
+  const utcMatch = value.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$/);
+  if (utcMatch) {
+    const [, y, mo, d, h, mi, s] = utcMatch;
+    return `${y}-${mo}-${d}T${h}:${mi}:${s}+00:00`;
+  }
+
+  const dtMatch = value.match(/^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2})(\d{2}))?$/);
+  if (!dtMatch) return null;
+  const year = Number(dtMatch[1]);
+  const month = Number(dtMatch[2]);
+  const day = Number(dtMatch[3]);
+  const hour = Number(dtMatch[4] ?? '0');
+  const minute = Number(dtMatch[5] ?? '0');
+  const second = Number(dtMatch[6] ?? '0');
+
+  // Treat the wall-clock as if it were UTC, then correct by the zone's
+  // offset. Resolve the offset twice so events near a DST transition land
+  // on the right side of the boundary.
+  const wallAsUtc = Date.UTC(year, month - 1, day, hour, minute, second);
+  let offset = timeZoneOffsetMs(wallAsUtc, timeZone);
+  offset = timeZoneOffsetMs(wallAsUtc - offset, timeZone);
+
+  const sign = offset >= 0 ? '+' : '-';
+  const absMin = Math.round(Math.abs(offset) / 60000);
+  const offHours = Math.floor(absMin / 60);
+  const offMins = absMin % 60;
+  return `${dtMatch[1]}-${dtMatch[2]}-${dtMatch[3]}T${pad(hour)}:${pad(minute)}:${pad(second)}${sign}${pad(offHours)}:${pad(offMins)}`;
+}
+
+// Pure and sync so it's easy to test against a saved .ics fixture.
+export function parseVevent(block: string, now = Date.now()): NormalizedEvent | null {
+  const props = parseIcsProperties(block);
+
+  const summary = props.SUMMARY?.value;
+  if (!summary) {
+    console.warn('[lawSchool] VEVENT missing SUMMARY — skipping');
+    return null;
+  }
+
+  const dtstart = props.DTSTART;
+  if (!dtstart) {
+    console.warn('[lawSchool] VEVENT missing DTSTART — skipping');
+    return null;
+  }
+  const tzid = dtstart.params.TZID ?? CALENDAR_TZ;
+  const startDatetime = icsDateToIso(dtstart.value, normalizeTzid(tzid));
+  if (!startDatetime) {
+    console.warn(`[lawSchool] Unparseable DTSTART "${dtstart.value}" — skipping`);
+    return null;
+  }
+
+  const dtend = props.DTEND;
+  const endDatetime = dtend
+    ? icsDateToIso(dtend.value, normalizeTzid(dtend.params.TZID ?? CALENDAR_TZ))
+    : null;
+
+  // Multi-hour/day events stay visible until they actually end; fall back to
+  // the start when there's no end.
+  const startMs = new Date(startDatetime).getTime();
+  if (isNaN(startMs)) return null;
+  const endMs = endDatetime ? new Date(endDatetime).getTime() : startMs;
+  if (endMs < now) return null;
+
+  const uid = props.UID?.value?.trim();
+  const eventUrl = props.URL?.value?.trim() || FEED_URL;
+  // UID is unique per occurrence; fall back to the event URL if it's absent.
+  const sourceEventId = uid || eventUrl;
+
+  const title = unescapeIcsText(summary).trim();
+  const description = stripHtml(unescapeIcsText(props.DESCRIPTION?.value ?? '')) || null;
+
+  const rawLocation = props.LOCATION ? unescapeIcsText(props.LOCATION.value).trim() : '';
+  const locationFull = rawLocation || null;
+
+  return {
+    source: SOURCE,
+    sourceEventId,
+    title,
+    description,
+    startDatetime,
+    endDatetime,
+    locationShort: truncateLocation(locationFull),
+    locationFull,
+    latitude: null,
+    longitude: null,
+    organization: {
+      // Law School is a department with no numeric org id, so ingest stores
+      // just the name on the event row and skips the organizations table.
+      sourceOrgId: null,
+      name: DEFAULT_ORG_NAME,
+      profilePicture: null,
+    },
+    eventUrl,
+    rsvpUrl: null,
+    imageUrl: null,
+    imageWidth: null,
+    imageHeight: null,
+    imageAspectRatio: 'none',
+    imageMimeType: null,
+    imageAltText: null,
+    theme: null,
+    visibility: 'Public',
+    rsvpTotal: 0,
+    categories: [],
+    benefits: [],
+  };
+}
+
+// The feed labels its zone "US/Central"; that alias resolves in Intl, but
+// normalize to the canonical IANA name to be safe across runtimes.
+function normalizeTzid(tzid: string): string {
+  return tzid === 'US/Central' ? CALENDAR_TZ : tzid;
+}
+
+export function parseFeed(icsText: string, now = Date.now()): NormalizedEvent[] {
+  const unfolded = unfoldIcs(icsText);
+  const events: NormalizedEvent[] = [];
+  for (const block of splitVevents(unfolded)) {
+    const parsed = parseVevent(block, now);
+    if (parsed) events.push(parsed);
+  }
+  return events;
+}
+
+export async function scrapeLawSchool(
+  db: D1Database,
+  options: { maxEvents?: number; dryRun?: boolean } = {},
+): Promise<ScraperResult> {
+  const dryRun = options.dryRun ?? false;
+  const maxEvents = options.maxEvents ?? DEFAULT_MAX_EVENTS;
+  const t0 = Date.now();
+
+  const errors: string[] = [];
+
+  let icsText: string;
+  try {
+    const res = await fetchWithRetry(FEED_URL, { headers: { Accept: 'text/calendar, */*' } });
+    icsText = await res.text();
+  } catch (err) {
+    const msg = `Fatal error fetching iCal feed: ${err}`;
+    console.error(`[lawSchool] ${msg}`);
+    return {
+      eventsProcessed: 0,
+      eventsUpserted: 0,
+      eventsSkipped: 0,
+      errors: [msg],
+      durationMs: Date.now() - t0,
+    };
+  }
+
+  const now = Date.now();
+  const blocks = splitVevents(unfoldIcs(icsText));
+  const eventsProcessed = blocks.length;
+
+  const normalized: NormalizedEvent[] = [];
+  for (const block of blocks) {
+    try {
+      const parsed = parseVevent(block, now);
+      if (parsed) normalized.push(parsed);
+    } catch (err) {
+      const msg = `Failed to parse VEVENT: ${err}`;
+      console.error(`[lawSchool] ${msg}`);
+      errors.push(msg);
+    }
+  }
+
+  const capped = normalized.slice(0, maxEvents);
+  const eventsSkipped = eventsProcessed - capped.length;
+  let eventsUpserted = 0;
+
+  if (dryRun) {
+    for (const event of capped) {
+      console.log(`[DRY RUN] "${event.title}" (${event.sourceEventId}) — ${event.startDatetime}`);
+    }
+  } else if (capped.length > 0) {
+    const result = await ingestEvents(db, capped);
+    eventsUpserted = result.inserted + result.updated;
+    errors.push(...result.errors);
+  }
+
+  const durationMs = Date.now() - t0;
+  console.log(
+    `[lawSchool] Finished in ${(durationMs / 1000).toFixed(1)}s — ${eventsUpserted} upserted, ${eventsSkipped} skipped, ${errors.length} errors`,
+  );
+
+  return { eventsProcessed, eventsUpserted, eventsSkipped, errors, durationMs };
+}
+
+export async function run(env: Env): Promise<void> {
+  console.log('[lawSchool] Scraper started');
+  await scrapeLawSchool(env.DB);
+}

--- a/server/src/scrapers/registry.ts
+++ b/server/src/scrapers/registry.ts
@@ -6,7 +6,7 @@
 //   run:     the (env) => Promise<void> cron entrypoint
 //   manual:  (optional) scrape function exposed via POST /events/scrape/:name
 //            Accepts the DB + a freeform options bag from the request body.
-// NOTE: Manual is used for testing and shold not be called in production 
+// NOTE: Manual is used for testing and shold not be called in production
 
 import type { Env } from '../worker';
 import { run as runHornsLink, scrapeHornsLink } from './hornslink';
@@ -31,8 +31,6 @@ export const SCRAPERS: ScraperEntry[] = [
 ];
 
 /** Lookup a scraper by route slug. */
-export function getManualScraper(
-  slug: string,
-): ScraperEntry['manual'] | undefined {
+export function getManualScraper(slug: string): ScraperEntry['manual'] | undefined {
   return SCRAPERS.find((s) => s.name === slug)?.manual;
 }

--- a/server/src/scrapers/registry.ts
+++ b/server/src/scrapers/registry.ts
@@ -2,23 +2,37 @@
 // scrape cron; adding a new scraper is one line here plus a new file.
 //
 // Each entry is:
-//   name: short id for logs / metrics
-//   run:  the (env) => Promise<void> cron entrypoint
+//   name:    short id used for logs, metrics, AND the manual trigger route slug
+//   run:     the (env) => Promise<void> cron entrypoint
+//   manual:  (optional) scrape function exposed via POST /events/scrape/:name
+//            Accepts the DB + a freeform options bag from the request body.
+// NOTE: Manual is used for testing and shold not be called in production 
 
-import { run as runHornsLink } from './hornslink';
-import { run as runMccombs } from './mccombs';
-import { run as runTexasGlobal } from './texasGlobal';
-import { run as runTexasToday } from './texasToday';
 import type { Env } from '../worker';
+import { run as runHornsLink, scrapeHornsLink } from './hornslink';
+import { run as runLawSchool, scrapeLawSchool } from './lawSchool';
+import { run as runMccombs, scrapeMccombs } from './mccombs';
+import { run as runTexasGlobal, scrapeTexasGlobal } from './texasGlobal';
+import { run as runTexasToday } from './texasToday';
 
 export interface ScraperEntry {
   name: string;
   run: (env: Env) => Promise<void>;
+  /** If provided, the scraper is available via POST /events/scrape/:name */
+  manual?: (db: D1Database, options: Record<string, unknown>) => Promise<unknown>;
 }
 
 export const SCRAPERS: ScraperEntry[] = [
-  { name: 'hornslink', run: runHornsLink },
+  { name: 'hornslink', run: runHornsLink, manual: scrapeHornsLink },
   { name: 'texasToday', run: runTexasToday },
-  { name: 'mccombs', run: runMccombs },
-  { name: 'texasGlobal', run: runTexasGlobal },
+  { name: 'mccombs', run: runMccombs, manual: scrapeMccombs },
+  { name: 'texasGlobal', run: runTexasGlobal, manual: scrapeTexasGlobal },
+  { name: 'lawSchool', run: runLawSchool, manual: scrapeLawSchool },
 ];
+
+/** Lookup a scraper by route slug. */
+export function getManualScraper(
+  slug: string,
+): ScraperEntry['manual'] | undefined {
+  return SCRAPERS.find((s) => s.name === slug)?.manual;
+}

--- a/server/test/scrapers/test_lawSchool.ts
+++ b/server/test/scrapers/test_lawSchool.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  icsDateToIso,
+  parseFeed,
+  parseIcsProperties,
+  parseVevent,
+  splitVevents,
+  unescapeIcsText,
+  unfoldIcs,
+} from '../../src/scrapers/lawSchool';
+
+function loadFixture(name: string): string {
+  return readFileSync(
+    join(__dirname, '..', '..', 'src', 'scrapers', '__fixtures__', 'lawSchool', name),
+    'utf-8',
+  );
+}
+
+// Far-future "now" so the fixture's dated events (2026/2027) all count as
+// upcoming, while the 2020 event is always in the past.
+const NOW_2026 = Date.parse('2026-07-01T00:00:00Z');
+
+describe('unfoldIcs', () => {
+  it('joins RFC 5545 folded continuation lines, consuming one leading space', () => {
+    // The single space after the CRLF is the fold marker and is removed; the
+    // real feed folds with two spaces so a content space survives.
+    const folded = 'DESCRIPTION:Hello\r\n  world\r\nLOCATION:Room 1\r\n';
+    expect(unfoldIcs(folded)).toBe('DESCRIPTION:Hello world\nLOCATION:Room 1\n');
+  });
+
+  it('handles LF-only folding too', () => {
+    expect(unfoldIcs('A:one\n two')).toBe('A:onetwo');
+  });
+});
+
+describe('unescapeIcsText', () => {
+  it('reverses iCal TEXT escaping', () => {
+    expect(unescapeIcsText('the Dean\\, hearing\\; and \\\\o/')).toBe(
+      'the Dean, hearing; and \\o/',
+    );
+  });
+
+  it('turns escaped newlines into real newlines', () => {
+    expect(unescapeIcsText('line one\\nline two')).toBe('line one\nline two');
+  });
+});
+
+describe('icsDateToIso', () => {
+  it('applies CDT (-05:00) for a summer Central date', () => {
+    expect(icsDateToIso('20260727T113000', 'America/Chicago')).toBe('2026-07-27T11:30:00-05:00');
+  });
+
+  it('applies CST (-06:00) for a winter Central date', () => {
+    expect(icsDateToIso('20270115T090000', 'America/Chicago')).toBe('2027-01-15T09:00:00-06:00');
+  });
+
+  it('passes through an explicit UTC (Z) value', () => {
+    expect(icsDateToIso('20260717T233000Z')).toBe('2026-07-17T23:30:00+00:00');
+  });
+
+  it('returns null for an unparseable value', () => {
+    expect(icsDateToIso('not-a-date')).toBeNull();
+  });
+});
+
+describe('parseIcsProperties', () => {
+  it('parses NAME;PARAM:VALUE lines with params', () => {
+    const block = 'DTSTART;VALUE=DATE-TIME;TZID=US/Central:20260727T113000\nSUMMARY:Hi';
+    const props = parseIcsProperties(block);
+    expect(props.DTSTART.value).toBe('20260727T113000');
+    expect(props.DTSTART.params.TZID).toBe('US/Central');
+    expect(props.SUMMARY.value).toBe('Hi');
+  });
+});
+
+describe('splitVevents', () => {
+  it('extracts each VEVENT block from the fixture', () => {
+    const blocks = splitVevents(unfoldIcs(loadFixture('feed.ics')));
+    expect(blocks.length).toBe(4);
+  });
+});
+
+describe('parseVevent', () => {
+  const blocks = splitVevents(unfoldIcs(loadFixture('feed.ics')));
+
+  it('parses a standard event with a folded HTML description', () => {
+    const parsed = parseVevent(blocks[0], NOW_2026);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.source).toBe('ut_law');
+    expect(parsed?.sourceEventId).toBe('20260727T113000-88639@law.utexas.edu');
+    expect(parsed?.title).toBe('Drawing Board Luncheon: Avihay Dorfman');
+    expect(parsed?.startDatetime).toBe('2026-07-27T11:30:00-05:00');
+    expect(parsed?.endDatetime).toBe('2026-07-27T12:45:00-05:00');
+    expect(parsed?.locationFull).toBe('TNH 2.111 - Sheffield-Massey Room');
+    expect(parsed?.locationShort).toBe('TNH 2.111 - Sheffield-Massey Room');
+    expect(parsed?.description).toContain('Drawing Board Luncheon');
+    expect(parsed?.description).not.toContain('<p>');
+    expect(parsed?.organization.name).toBe('The University of Texas School of Law');
+    expect(parsed?.organization.sourceOrgId).toBeNull();
+    expect(parsed?.imageUrl).toBeNull();
+    expect(parsed?.imageAspectRatio).toBe('none');
+    expect(parsed?.visibility).toBe('Public');
+  });
+
+  it('handles an event with an empty LOCATION and escaped commas', () => {
+    const parsed = parseVevent(blocks[1], NOW_2026);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.title).toBe('Alumni Breakfast at NBA');
+    expect(parsed?.locationFull).toBeNull();
+    expect(parsed?.locationShort).toBeNull();
+    // "the Dean\, hearing" should unescape to a plain comma.
+    expect(parsed?.description).toContain('the Dean, hearing');
+  });
+
+  it('skips events that have already ended', () => {
+    const past = blocks.find((b) => b.includes('Should Be Skipped'))!;
+    expect(parseVevent(past, NOW_2026)).toBeNull();
+  });
+});
+
+describe('parseFeed', () => {
+  it('returns only upcoming events from the fixture', () => {
+    const events = parseFeed(loadFixture('feed.ics'), NOW_2026);
+    expect(events.map((e) => e.title)).toEqual([
+      'Drawing Board Luncheon: Avihay Dorfman',
+      'Alumni Breakfast at NBA',
+      'Spring Semester Kickoff',
+    ]);
+  });
+});


### PR DESCRIPTION
Add a new iCal-based scraper for the UT Law School calendar with
fixture data and unit tests. 

Extend the scraper registry with an optional \`manual\` field so each scraper self-registers its trigger function

Replace the three repetitive POST /events/scrape/* handlers with a single dynamic POST /events/scrape/:name route driven by the registry. 

Also add a \`source\` query param filter to GET /events to see scraped events easily 