### PR TITLE
refactor(ingest): pass env instead of db through scrapers and ingestEvents

### DIFF
--- a/server/src/events/ingest.ts
+++ b/server/src/events/ingest.ts
@@ -1,6 +1,7 @@
 // Writes NormalizedEvent[] into D1. Only place that knows the schema.
 
 import type { IngestResult, NormalizedEvent } from './types';
+import type { Env } from '../worker';
 import { classifyEvent, writeEventTags } from '../lib/classifier';
 
 // LOOP-150 retention window. Purge job uses expires_at.
@@ -172,10 +173,12 @@ async function replaceCategoriesAndBenefits(
 }
 
 // Per-event errors are isolated so one bad row doesn't sink the batch.
+// Takes the whole env (not just db) so tagging can reach bindings beyond D1.
 export async function ingestEvents(
-  db: D1Database,
+  env: Env,
   events: NormalizedEvent[],
 ): Promise<IngestResult> {
+  const db = env.DB;
   const result: IngestResult = { inserted: 0, updated: 0, errors: [] };
 
   for (const event of events) {

--- a/server/src/events/ingest.ts
+++ b/server/src/events/ingest.ts
@@ -174,10 +174,7 @@ async function replaceCategoriesAndBenefits(
 
 // Per-event errors are isolated so one bad row doesn't sink the batch.
 // Takes the whole env (not just db) so tagging can reach bindings beyond D1.
-export async function ingestEvents(
-  env: Env,
-  events: NormalizedEvent[],
-): Promise<IngestResult> {
+export async function ingestEvents(env: Env, events: NormalizedEvent[]): Promise<IngestResult> {
   const db = env.DB;
   const result: IngestResult = { inserted: 0, updated: 0, errors: [] };
 

--- a/server/src/routes/events.worker.ts
+++ b/server/src/routes/events.worker.ts
@@ -1159,7 +1159,7 @@ eventRoutes.post('/scrape/:name', async (c) => {
   }
 
   const body = await c.req.json().catch(() => ({}));
-  const result = await scraper(c.env.DB, body as Record<string, unknown>);
+  const result = await scraper(c.env, body as Record<string, unknown>);
 
   return c.json(result);
 });

--- a/server/src/scrapers/cns.ts
+++ b/server/src/scrapers/cns.ts
@@ -253,7 +253,7 @@ export async function run(env: Env): Promise<void> {
 
   console.log(`[cns] Parsed ${events.length} event instances`);
 
-  const { inserted, updated, errors } = await ingestEvents(env.DB, events);
+  const { inserted, updated, errors } = await ingestEvents(env, events);
   const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
 
   console.log(

--- a/server/src/scrapers/cockrell.ts
+++ b/server/src/scrapers/cockrell.ts
@@ -203,7 +203,7 @@ export async function fetchAllEvents(): Promise<WpEvent[]> {
 }
 
 export async function scrapeCockrell(
-  db: D1Database,
+  env: Env,
   options: { dryRun?: boolean } = {},
 ): Promise<ScraperResult> {
   const dryRun = options.dryRun ?? false;
@@ -264,7 +264,7 @@ export async function scrapeCockrell(
   }
 
   if (!dryRun && normalized.length > 0) {
-    const result = await ingestEvents(db, normalized);
+    const result = await ingestEvents(env, normalized);
     eventsUpserted = result.inserted + result.updated;
     errors.push(...result.errors);
   }
@@ -279,5 +279,5 @@ export async function scrapeCockrell(
 
 export async function run(env: Env): Promise<void> {
   console.log('[cockrell] Scraper started');
-  await scrapeCockrell(env.DB);
+  await scrapeCockrell(env);
 }

--- a/server/src/scrapers/finearts.ts
+++ b/server/src/scrapers/finearts.ts
@@ -215,7 +215,7 @@ export async function discoverEventRows(): Promise<string[]> {
 }
 
 export async function scrapeFineArts(
-  db: D1Database,
+  env: Env,
   options: { maxEvents?: number; dryRun?: boolean } = {},
 ): Promise<ScraperResult> {
   const dryRun = options.dryRun ?? false;
@@ -271,7 +271,7 @@ export async function scrapeFineArts(
   }
 
   if (!dryRun && normalized.length > 0) {
-    const result = await ingestEvents(db, normalized);
+    const result = await ingestEvents(env, normalized);
     eventsUpserted = result.inserted + result.updated;
     errors.push(...result.errors);
   }
@@ -286,5 +286,5 @@ export async function scrapeFineArts(
 
 export async function run(env: Env): Promise<void> {
   console.log('[finearts] Scraper started');
-  await scrapeFineArts(env.DB);
+  await scrapeFineArts(env);
 }

--- a/server/src/scrapers/hornslink.ts
+++ b/server/src/scrapers/hornslink.ts
@@ -138,7 +138,7 @@ function toNormalizedEvent(raw: HornsLinkEvent): NormalizedEvent {
 // Main scraper
 
 export async function scrapeHornsLink(
-  db: D1Database,
+  env: Env,
   options?: { maxPages?: number; dryRun?: boolean; timeBudgetMs?: number },
 ): Promise<ScraperResult> {
   const startTime = Date.now();
@@ -202,7 +202,7 @@ export async function scrapeHornsLink(
         }
       } else {
         const normalized = inWindow.map(toNormalizedEvent);
-        const ingested = await ingestEvents(db, normalized);
+        const ingested = await ingestEvents(env, normalized);
         result.eventsInserted += ingested.inserted;
         result.eventsUpdated += ingested.updated;
         result.errors.push(...ingested.errors);
@@ -231,7 +231,7 @@ export async function scrapeHornsLink(
 // Cron entrypoint. Larger page budget than the manual scrape route.
 export async function run(env: Env): Promise<void> {
   console.log('[HornsLink] Cron scrape started');
-  const result = await scrapeHornsLink(env.DB, { maxPages: CRON_MAX_PAGES });
+  const result = await scrapeHornsLink(env, { maxPages: CRON_MAX_PAGES });
   if (result.errors.length > 0) {
     console.error(
       `[HornsLink] Cron run had ${result.errors.length} event-level error(s):`,

--- a/server/src/scrapers/lawSchool.ts
+++ b/server/src/scrapers/lawSchool.ts
@@ -248,7 +248,7 @@ export function parseFeed(icsText: string, now = Date.now()): NormalizedEvent[] 
 }
 
 export async function scrapeLawSchool(
-  db: D1Database,
+  env: Env,
   options: { maxEvents?: number; dryRun?: boolean } = {},
 ): Promise<ScraperResult> {
   const dryRun = options.dryRun ?? false;
@@ -298,7 +298,7 @@ export async function scrapeLawSchool(
       console.log(`[DRY RUN] "${event.title}" (${event.sourceEventId}) — ${event.startDatetime}`);
     }
   } else if (capped.length > 0) {
-    const result = await ingestEvents(db, capped);
+    const result = await ingestEvents(env, capped);
     eventsUpserted = result.inserted + result.updated;
     errors.push(...result.errors);
   }
@@ -313,5 +313,5 @@ export async function scrapeLawSchool(
 
 export async function run(env: Env): Promise<void> {
   console.log('[lawSchool] Scraper started');
-  await scrapeLawSchool(env.DB);
+  await scrapeLawSchool(env);
 }

--- a/server/src/scrapers/mccombs.ts
+++ b/server/src/scrapers/mccombs.ts
@@ -223,7 +223,7 @@ export async function discoverEventUrls(): Promise<string[]> {
 }
 
 export async function scrapeMccombs(
-  db: D1Database,
+  env: Env,
   options: { maxEvents?: number; dryRun?: boolean } = {},
 ): Promise<ScraperResult> {
   const dryRun = options.dryRun ?? false;
@@ -295,7 +295,7 @@ export async function scrapeMccombs(
   }
 
   if (!dryRun && normalized.length > 0) {
-    const result = await ingestEvents(db, normalized);
+    const result = await ingestEvents(env, normalized);
     eventsUpserted = result.inserted + result.updated;
     errors.push(...result.errors);
   }
@@ -310,5 +310,5 @@ export async function scrapeMccombs(
 
 export async function run(env: Env): Promise<void> {
   console.log('[mccombs] Scraper started');
-  await scrapeMccombs(env.DB);
+  await scrapeMccombs(env);
 }

--- a/server/src/scrapers/registry.ts
+++ b/server/src/scrapers/registry.ts
@@ -5,7 +5,7 @@
 //   name:    short id used for logs, metrics, AND the manual trigger route slug
 //   run:     the (env) => Promise<void> cron entrypoint
 //   manual:  (optional) scrape function exposed via POST /events/scrape/:name
-//            Accepts the DB + a freeform options bag from the request body.
+//            Accepts env + a freeform options bag from the request body.
 // NOTE: Manual is used for testing and shold not be called in production
 
 import type { Env } from '../worker';
@@ -22,7 +22,7 @@ export interface ScraperEntry {
   name: string;
   run: (env: Env) => Promise<void>;
   /** If provided, the scraper is available via POST /events/scrape/:name */
-  manual?: (db: D1Database, options: Record<string, unknown>) => Promise<unknown>;
+  manual?: (env: Env, options: Record<string, unknown>) => Promise<unknown>;
 }
 
 export const SCRAPERS: ScraperEntry[] = [

--- a/server/src/scrapers/texasGlobal.ts
+++ b/server/src/scrapers/texasGlobal.ts
@@ -250,7 +250,7 @@ export async function discoverEventCards(): Promise<string[]> {
 }
 
 export async function scrapeTexasGlobal(
-  db: D1Database,
+  env: Env,
   options: { maxEvents?: number; dryRun?: boolean } = {},
 ): Promise<ScraperResult> {
   const dryRun = options.dryRun ?? false;
@@ -332,7 +332,7 @@ export async function scrapeTexasGlobal(
   }
 
   if (!dryRun && normalized.length > 0) {
-    const result = await ingestEvents(db, normalized);
+    const result = await ingestEvents(env, normalized);
     eventsUpserted = result.inserted + result.updated;
     errors.push(...result.errors);
   }
@@ -347,5 +347,5 @@ export async function scrapeTexasGlobal(
 
 export async function run(env: Env): Promise<void> {
   console.log('[texasGlobal] Scraper started');
-  await scrapeTexasGlobal(env.DB);
+  await scrapeTexasGlobal(env);
 }

--- a/server/src/scrapers/texasToday.ts
+++ b/server/src/scrapers/texasToday.ts
@@ -241,7 +241,7 @@ export async function run(env: Env): Promise<void> {
 
   console.log(`[texasToday] Parsed ${events.length} event instances`);
 
-  const { inserted, updated, errors } = await ingestEvents(env.DB, events);
+  const { inserted, updated, errors } = await ingestEvents(env, events);
   const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
 
   console.log(


### PR DESCRIPTION
Threads the full `env` through the ingest path instead of just `db`, so tagging can reach bindings beyond D1 (needed by the upcoming semantic classifier).

No behavior change. Ingest still uses the keyword classifier; this is pure plumbing.

- `ingestEvents(db, ...)` -> `ingestEvents(env, ...)`, using `env.DB` internally
- 8 scrapers and the registry updated to pass `env`
- `/scrape/:name` and manual scraper type signature updated to match

Split out ahead of the Phase 5 semantic-tagging PR to keep that review focused.

Typecheck clean, all 116 tests pass.