### PR TITLE
[LOOP-235] Add College of Pharmacy events scraper

### DIFF
--- a/server/src/scrapers/__fixtures__/pharmacy/commencement.json
+++ b/server/src/scrapers/__fixtures__/pharmacy/commencement.json
@@ -1,0 +1,49 @@
+{
+  "event": {
+    "id": 49454950427592,
+    "title": "College of Pharmacy Undergraduate, Graduate, & Doctoral Commencement",
+    "description": "<p>The College of Pharmacy holds commencement ceremonies each May to honor our graduates. Attendance at the graduation ceremony is optional.&nbsp; The commencement speaker will be Dr. Cheryl Beal Anderson.</p>",
+    "location": "",
+    "location_name": "Bass Concert Hall, Performing Arts Center (PAC)",
+    "room_number": null,
+    "address": "2350 Robert Dedman Drive, Austin, TX 78712",
+    "url": null,
+    "localist_url": "https://calendar.utexas.edu/event/college-of-pharmacy-undergraduate-commencement",
+    "photo_url": "https://localist-images.azureedge.net/photos/49454961151031/huge/e796b4e1be7d2525ead7c720042f260e7bb9c2fc.jpg",
+    "photo_width": 275,
+    "photo_height": 183,
+    "photo_alt": null,
+    "photo_content_type": "image/jpeg",
+    "departments": [
+      {
+        "id": 47748554254291,
+        "name": "College of Pharmacy"
+      }
+    ],
+    "filters": {
+      "event_target_audience": [
+        { "name": "Students", "id": 24848 },
+        { "name": "Faculty", "id": 24850 },
+        { "name": "Families", "id": 24852 }
+      ],
+      "event_types": [{ "name": "Academics", "id": 24828 }]
+    },
+    "tags": ["ceremonies"],
+    "keywords": [],
+    "geo": {
+      "latitude": "30.285816",
+      "longitude": "-97.73098"
+    },
+    "event_instances": [
+      {
+        "event_instance": {
+          "id": 49454950428617,
+          "event_id": 49454950427592,
+          "start": "2025-05-09T08:00:00-05:00",
+          "end": "2025-05-09T10:00:00-05:00",
+          "all_day": false
+        }
+      }
+    ]
+  }
+}

--- a/server/src/scrapers/pharmacy.ts
+++ b/server/src/scrapers/pharmacy.ts
@@ -1,0 +1,299 @@
+// College of Pharmacy scraper: calendar.utexas.edu (Localist JSON API),
+// scoped to the Pharmacy department via group_id.
+//
+// Pharmacy events are relatively sparse, so each run requests the next
+// 365 days and follows every page returned by Localist.
+//
+// Dedup key: instance_id, not event_id, so recurring events get one row
+// per occurrence. ingestEvents upserts on (source, source_event_id).
+
+import { ingestEvents } from '../events/ingest';
+import {
+  classifyAspectRatio,
+  fetchImageMeta,
+  parseCoordinate,
+  stripHtml,
+} from '../events/normalize';
+import { fetchWithRetry } from '../events/polite-fetch';
+import type { ImageAspectRatio, NormalizedEvent } from '../events/types';
+import type { Env } from '../worker';
+
+const API_BASE = 'https://calendar.utexas.edu/api/2/events';
+// Confirmed against https://calendar.utexas.edu/department/college-of-pharmacy.
+const GROUP_ID = 47748554254291;
+const PER_PAGE = 100;
+const DAYS_AHEAD = 365;
+export const SOURCE = 'pharmacy';
+const DEFAULT_ORG_NAME = 'College of Pharmacy';
+
+// Localist returns event definitions containing one or more dated instances.
+// Several properties are optional because the list API omits them when the
+// event submitter did not provide a value.
+export interface LocalistEventInstance {
+  event_instance: {
+    id: number;
+    event_id: number;
+    start: string;
+    end: string | null;
+    all_day: boolean;
+  };
+}
+
+export interface LocalistDepartment {
+  id?: number;
+  name: string;
+  url?: string;
+  localist_url?: string;
+  hashtag?: string;
+}
+
+export interface LocalistRawEvent {
+  event: {
+    id: number;
+    title: string;
+    description: string | null;
+    location?: string | null;
+    location_name?: string | null;
+    room?: string | null;
+    room_number?: string | null;
+    address: string | null;
+    url: string | null;
+    localist_url: string;
+    event_instances: LocalistEventInstance[];
+    photo_url: string | null;
+    photo_width?: number | null;
+    photo_height?: number | null;
+    photo_alt?: string | null;
+    photo_content_type?: string | null;
+    departments: LocalistDepartment[];
+    filters: Record<string, { name: string; id: number }[]>;
+    tags: string[];
+    keywords: string[];
+    geo?: {
+      latitude?: string | null;
+      longitude?: string | null;
+    } | null;
+  };
+}
+
+interface LocalistApiResponse {
+  events: LocalistRawEvent[];
+  page: {
+    current: number;
+    size: number;
+    // Localist reports the number of pages here, not the number of events.
+    total: number;
+  };
+}
+
+// Removes a trailing street address and enforces the events table's
+// display-friendly 40-character short-location convention.
+function buildLocationShort(location: string | null | undefined): string | null {
+  if (!location) return null;
+  const stripped = location.replace(/,\s*\d+[^,]*$/, '').trim();
+  const candidate = stripped || location.trim();
+  if (candidate.length <= 40) return candidate;
+  return candidate.substring(0, 37) + '...';
+}
+
+function buildLocationFull(
+  location: string | null | undefined,
+  address: string | null | undefined,
+): string | null {
+  const parts = [location?.trim(), address?.trim()].filter(Boolean);
+  return parts.length > 0 ? parts.join(', ') : null;
+}
+
+// Localist image URLs may point at resized variants. Store the largest
+// available version so clients are not limited to a thumbnail.
+function upgradeImageUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return url
+    .replace(/\/thumb\//, '/huge/')
+    .replace(/\/medium\//, '/huge/')
+    .replace(/\/small\//, '/huge/');
+}
+
+// Current Localist responses use location_name/room_number, while older
+// responses and saved CNS fixtures use location/room. Support both shapes.
+function buildVenue(event: LocalistRawEvent['event']): string | null {
+  const venue = event.location_name?.trim() || event.location?.trim();
+  const room = event.room_number?.trim() || event.room?.trim();
+  return [venue, room].filter(Boolean).join(', ') || null;
+}
+
+export function parseEventInstance(
+  raw: LocalistRawEvent,
+  instance: LocalistEventInstance,
+): NormalizedEvent | null {
+  const event = raw.event;
+  const eventInstance = instance.event_instance;
+
+  if (!eventInstance.start) {
+    console.warn(
+      `[pharmacy] Event ${event.id} instance ${eventInstance.id} missing start time — skipping`,
+    );
+    return null;
+  }
+
+  // Co-hosted events may list another department first. Prefer the Pharmacy
+  // department explicitly, then fall back to the first available department.
+  const department =
+    event.departments?.find((item) => item.name === DEFAULT_ORG_NAME) ??
+    event.departments?.[0] ??
+    null;
+
+  // Categories combine free-form tags and Localist event-type filters while
+  // preserving source order and removing duplicates.
+  const seen = new Set<string>();
+  const categories: { id: string; name: string | null }[] = [];
+  for (const tag of [
+    ...(event.tags ?? []),
+    ...(event.filters?.event_types?.map((item) => item.name) ?? []),
+  ]) {
+    if (tag && !seen.has(tag)) {
+      seen.add(tag);
+      categories.push({ id: tag.toLowerCase().replace(/\s+/g, '-'), name: tag });
+    }
+  }
+
+  const imageUrl = upgradeImageUrl(event.photo_url);
+  const hasImage = Boolean(imageUrl);
+  let imageAspectRatio: ImageAspectRatio = 'none';
+  if (hasImage) {
+    const classified = classifyAspectRatio(event.photo_width, event.photo_height, true);
+    // If metadata lookup fails, retain the established Localist fallback:
+    // images with unknown dimensions are treated as horizontal.
+    imageAspectRatio = classified === 'square' && !event.photo_width ? 'horizontal' : classified;
+  }
+
+  const venue = buildVenue(event);
+
+  return {
+    source: SOURCE,
+    sourceEventId: String(eventInstance.id),
+    title: event.title,
+    description: stripHtml(event.description),
+    startDatetime: eventInstance.start,
+    endDatetime: eventInstance.end ?? null,
+    locationShort: buildLocationShort(venue || event.address),
+    locationFull: buildLocationFull(venue, event.address),
+    latitude: parseCoordinate(event.geo?.latitude ?? null),
+    longitude: parseCoordinate(event.geo?.longitude ?? null),
+    organization: {
+      // Localist department IDs are not organization records in our schema,
+      // so ingest stores the display name without upserting an organization.
+      sourceOrgId: null,
+      name: department?.name ?? DEFAULT_ORG_NAME,
+      profilePicture: null,
+    },
+    eventUrl: event.localist_url || event.url || '',
+    rsvpUrl: null,
+    imageUrl,
+    imageAspectRatio,
+    imageWidth: hasImage ? (event.photo_width ?? null) : null,
+    imageHeight: hasImage ? (event.photo_height ?? null) : null,
+    imageMimeType: hasImage ? (event.photo_content_type ?? null) : null,
+    imageAltText: hasImage ? (event.photo_alt ?? null) : null,
+    theme: null,
+    visibility: 'Public',
+    rsvpTotal: 0,
+    categories,
+    benefits: [],
+  };
+}
+
+// A Localist event can contain multiple occurrences. Emit one normalized row
+// for each upcoming instance and isolate malformed instances from siblings.
+export function parseEvent(raw: LocalistRawEvent, now = Date.now()): NormalizedEvent[] {
+  const instances = raw.event?.event_instances ?? [];
+  if (instances.length === 0) {
+    console.warn(`[pharmacy] Event ${raw.event?.id} has no instances — skipping`);
+    return [];
+  }
+
+  const results: NormalizedEvent[] = [];
+  for (const instance of instances) {
+    const startMs = new Date(instance.event_instance.start).getTime();
+    if (isNaN(startMs) || startMs < now) continue;
+
+    try {
+      const parsed = parseEventInstance(raw, instance);
+      if (parsed) results.push(parsed);
+    } catch (err) {
+      console.error(
+        `[pharmacy] Failed to parse instance ${instance.event_instance.id} of event ${raw.event?.id}: ${err}`,
+      );
+    }
+  }
+  return results;
+}
+
+// The Localist list API usually supplies an image URL without dimensions.
+// Range-read the image header only when metadata is missing, allowing accurate
+// vertical/square/horizontal classification without downloading the full file.
+async function hydrateImageMetadata(raw: LocalistRawEvent): Promise<void> {
+  const imageUrl = upgradeImageUrl(raw.event.photo_url);
+  if (!imageUrl || (raw.event.photo_width && raw.event.photo_height)) return;
+
+  const metadata = await fetchImageMeta(imageUrl, SOURCE);
+  raw.event.photo_width = metadata.width;
+  raw.event.photo_height = metadata.height;
+  raw.event.photo_content_type ??= metadata.mimeType;
+}
+
+async function fetchPage(page: number): Promise<LocalistApiResponse> {
+  const url =
+    `${API_BASE}?group_id=${GROUP_ID}&days=${DAYS_AHEAD}` + `&per_page=${PER_PAGE}&page=${page}`;
+  const response = await fetchWithRetry(url);
+  return response.json() as Promise<LocalistApiResponse>;
+}
+
+export async function fetchAllEvents(): Promise<NormalizedEvent[]> {
+  const parsed: NormalizedEvent[] = [];
+  let page = 1;
+  let totalPages = 1;
+  const now = Date.now();
+
+  do {
+    console.log(`[pharmacy] Fetching page ${page}/${totalPages}...`);
+    const data = await fetchPage(page);
+    totalPages = data.page.total;
+
+    // One malformed event or failed metadata lookup must not discard the rest
+    // of the page. ingestEvents provides the same isolation during D1 writes.
+    for (const rawEvent of data.events) {
+      try {
+        await hydrateImageMetadata(rawEvent);
+        parsed.push(...parseEvent(rawEvent, now));
+      } catch (err) {
+        console.error(`[pharmacy] Unhandled parse error for event ${rawEvent.event?.id}: ${err}`);
+      }
+    }
+
+    page++;
+  } while (page <= totalPages);
+
+  return parsed;
+}
+
+// Scheduled Cloudflare Worker entrypoint.
+export async function run(env: Env): Promise<void> {
+  console.log('[pharmacy] Scraper started');
+  const startedAt = Date.now();
+
+  let events: NormalizedEvent[];
+  try {
+    events = await fetchAllEvents();
+  } catch (err) {
+    console.error(`[pharmacy] Fatal fetch error — aborting run: ${err}`);
+    return;
+  }
+
+  console.log(`[pharmacy] Parsed ${events.length} event instances`);
+  const { inserted, updated, errors } = await ingestEvents(env, events);
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+  console.log(
+    `[pharmacy] Finished in ${elapsed}s — ${inserted} inserted, ${updated} updated, ${errors.length} errors`,
+  );
+}

--- a/server/src/scrapers/registry.ts
+++ b/server/src/scrapers/registry.ts
@@ -15,6 +15,7 @@ import { run as runCns } from './cns';
 import { run as runHornsLink, scrapeHornsLink } from './hornslink';
 import { run as runLawSchool, scrapeLawSchool } from './lawSchool';
 import { run as runMccombs, scrapeMccombs } from './mccombs';
+import { run as runPharmacy } from './pharmacy';
 import { run as runTexasGlobal, scrapeTexasGlobal } from './texasGlobal';
 import { run as runTexasToday } from './texasToday';
 
@@ -34,6 +35,7 @@ export const SCRAPERS: ScraperEntry[] = [
   { name: 'cockrell', run: runCockrell, manual: scrapeCockrell },
   { name: 'cofa', run: runFineArts, manual: scrapeFineArts },
   { name: 'cns', run: runCns },
+  { name: 'pharmacy', run: runPharmacy },
 ];
 
 /** Lookup a scraper by route slug. */

--- a/server/test/scrapers/test_pharmacy.ts
+++ b/server/test/scrapers/test_pharmacy.ts
@@ -1,0 +1,158 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchAllEvents,
+  parseEvent,
+  parseEventInstance,
+  type LocalistRawEvent,
+} from '../../src/scrapers/pharmacy';
+
+function loadFixture(): LocalistRawEvent {
+  return JSON.parse(
+    readFileSync(
+      join(
+        __dirname,
+        '..',
+        '..',
+        'src',
+        'scrapers',
+        '__fixtures__',
+        'pharmacy',
+        'commencement.json',
+      ),
+      'utf-8',
+    ),
+  );
+}
+
+const NOW = new Date('2025-05-01T00:00:00Z').getTime();
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Pharmacy Localist scraper', () => {
+  it('maps a saved Pharmacy event into the shared event schema', () => {
+    const results = parseEvent(loadFixture(), NOW);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      source: 'pharmacy',
+      sourceEventId: '49454950428617',
+      title: 'College of Pharmacy Undergraduate, Graduate, & Doctoral Commencement',
+      description:
+        'The College of Pharmacy holds commencement ceremonies each May to honor our graduates. Attendance at the graduation ceremony is optional. The commencement speaker will be Dr. Cheryl Beal Anderson.',
+      startDatetime: '2025-05-09T08:00:00-05:00',
+      endDatetime: '2025-05-09T10:00:00-05:00',
+      locationShort: 'Bass Concert Hall, Performing Arts Ce...',
+      locationFull:
+        'Bass Concert Hall, Performing Arts Center (PAC), 2350 Robert Dedman Drive, Austin, TX 78712',
+      latitude: 30.285816,
+      longitude: -97.73098,
+      organization: {
+        sourceOrgId: null,
+        name: 'College of Pharmacy',
+        profilePicture: null,
+      },
+      eventUrl: 'https://calendar.utexas.edu/event/college-of-pharmacy-undergraduate-commencement',
+      imageWidth: 275,
+      imageHeight: 183,
+      imageAspectRatio: 'horizontal',
+      imageMimeType: 'image/jpeg',
+      categories: [
+        { id: 'ceremonies', name: 'ceremonies' },
+        { id: 'academics', name: 'Academics' },
+      ],
+    });
+  });
+
+  it.each([
+    [300, 600, 'vertical'],
+    [500, 500, 'square'],
+    [600, 300, 'horizontal'],
+  ] as const)('classifies a %s x %s image as %s', (width, height, expected) => {
+    const raw = loadFixture();
+    raw.event.photo_width = width;
+    raw.event.photo_height = height;
+
+    const parsed = parseEvent(raw, NOW);
+    expect(parsed[0].imageAspectRatio).toBe(expected);
+  });
+
+  it('uses none when the source has no image', () => {
+    const raw = loadFixture();
+    raw.event.photo_url = null;
+
+    const parsed = parseEvent(raw, NOW);
+    expect(parsed[0].imageAspectRatio).toBe('none');
+    expect(parsed[0].imageWidth).toBeNull();
+    expect(parsed[0].imageHeight).toBeNull();
+  });
+
+  it('isolates invalid instances and keeps valid recurring instances', () => {
+    const raw = loadFixture();
+    raw.event.event_instances.unshift({
+      event_instance: {
+        id: 49454950428616,
+        event_id: raw.event.id,
+        start: 'not-a-date',
+        end: null,
+        all_day: false,
+      },
+    });
+    raw.event.event_instances.push({
+      event_instance: {
+        id: 49454950428618,
+        event_id: raw.event.id,
+        start: '2025-05-10T08:00:00-05:00',
+        end: null,
+        all_day: false,
+      },
+    });
+
+    expect(parseEvent(raw, NOW).map((event) => event.sourceEventId)).toEqual([
+      '49454950428617',
+      '49454950428618',
+    ]);
+  });
+
+  it('returns null for an instance missing its required start datetime', () => {
+    const raw = loadFixture();
+    const instance = raw.event.event_instances[0];
+    instance.event_instance.start = '';
+
+    expect(parseEventInstance(raw, instance)).toBeNull();
+  });
+
+  it('fetches every page of upcoming department events', async () => {
+    const pageOneEvent = loadFixture();
+    pageOneEvent.event.photo_url = null;
+    pageOneEvent.event.event_instances[0].event_instance.id = 70000000000001;
+    pageOneEvent.event.event_instances[0].event_instance.start = '2099-05-09T08:00:00-05:00';
+
+    const pageTwoEvent = structuredClone(pageOneEvent);
+    pageTwoEvent.event.event_instances[0].event_instance.id = 70000000000002;
+
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const page = new URL(String(url)).searchParams.get('page');
+      const body = {
+        events: [page === '1' ? pageOneEvent : pageTwoEvent],
+        page: { current: Number(page), size: 1, total: 2 },
+      };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const events = await fetchAllEvents();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(events.map((event) => event.sourceEventId)).toEqual([
+      '70000000000001',
+      '70000000000002',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a department-specific scraper for UT College of Pharmacy events from:

https://calendar.utexas.edu/department/college-of-pharmacy

## Changes

- Added `server/src/scrapers/pharmacy.ts`
- Fetches upcoming Pharmacy events through the Localist JSON API
- Paginates through all available event pages
- Extracts and normalizes:
  - Title and description
  - Start and end datetimes
  - Short and full location
  - Coordinates
  - Host organization
  - Event URL
  - Image URL, dimensions, MIME type, alt text, and aspect ratio
  - Categories
- Classifies images as `vertical`, `square`, `horizontal`, or `none`
- Uses the Localist event instance ID as the stable `source_event_id`
- Supports recurring events as separate event instances
- Isolates per-event parsing and ingestion errors
- Upserts events through the shared D1 ingestion pipeline
- Registered the Pharmacy scraper with the scheduled scraper registry
- Added a saved Pharmacy event fixture and unit tests for:
  - Event normalization
  - Image aspect-ratio classification
  - Missing images
  - Recurring and invalid instances
  - Pagination

## Testing

- Full server test suite: 124 tests passed
- Pharmacy/CNS regression tests: 21 tests passed
- Server TypeScript build passed
- Root TypeScript typecheck passed
- ESLint passed with 0 errors
- Staged diff validation passed

Closes LOOP-235