### PR TITLE
feat(scraper): add College of Liberal Arts events scraper (LOOP-233)

### DIFF
--- a/server/src/scrapers/__fixtures__/liberalArts/last-page.json
+++ b/server/src/scrapers/__fixtures__/liberalArts/last-page.json
@@ -1,0 +1,40 @@
+{
+  "meta": {
+    "page": {
+      "current-page": 2,
+      "per-page": 15,
+      "total": 2,
+      "last-page": 2
+    }
+  },
+  "links": {
+    "first": "https://webeditor.la.utexas.edu/api/v2/events?filter%5Bdivision%5D=public-affairs&page%5Bnumber%5D=1",
+    "last": "https://webeditor.la.utexas.edu/api/v2/events?filter%5Bdivision%5D=public-affairs&page%5Bnumber%5D=2"
+  },
+  "data": [
+    {
+      "type": "events",
+      "id": "61030",
+      "attributes": {
+        "title": "Constitution Day 2026 with Tom Merrill",
+        "summary": "A discussion of the Constitution.",
+        "body_content": null,
+        "location": "Avaya Auditorium POB 2.302",
+        "date": "Tuesday September 15, 2026",
+        "weekday": "Tue",
+        "day": "15",
+        "month": "Sep",
+        "year": "2026",
+        "begin_time": "4:00 PM",
+        "end_time": "5:30 PM",
+        "publish_date": "2026-05-26",
+        "sponsor": null,
+        "image": null,
+        "image_caption": null,
+        "image_path": null,
+        "full_image_path": "https://minio.la.utexas.edu/colaweb-prod/",
+        "slug": "constitution-day-2026-with-tom-merrill-2"
+      }
+    }
+  ]
+}

--- a/server/src/scrapers/__fixtures__/liberalArts/listing-page.json
+++ b/server/src/scrapers/__fixtures__/liberalArts/listing-page.json
@@ -1,0 +1,65 @@
+{
+  "meta": {
+    "page": {
+      "current-page": 1,
+      "per-page": 15,
+      "total": 2,
+      "last-page": 2
+    }
+  },
+  "links": {
+    "first": "https://webeditor.la.utexas.edu/api/v2/events?filter%5Bdivision%5D=public-affairs&page%5Bnumber%5D=1",
+    "next": "https://webeditor.la.utexas.edu/api/v2/events?filter%5Bdivision%5D=public-affairs&page%5Bnumber%5D=2",
+    "last": "https://webeditor.la.utexas.edu/api/v2/events?filter%5Bdivision%5D=public-affairs&page%5Bnumber%5D=2"
+  },
+  "data": [
+    {
+      "type": "events",
+      "id": "61021",
+      "attributes": {
+        "title": "Opening Lecture with Professor Devin Stauffer,&nbsp;&quot;Reading the Great Books in the Age of AI&quot;",
+        "summary": null,
+        "body_content": "<p>&nbsp;</p><p>This lecture will be followed by a Pizza and Pool party at the Outdoor Rec Pool at Gregory Gym.&nbsp;</p>",
+        "location": "Avaya Auditorium POB 2.302",
+        "date": "Thursday August 27, 2026",
+        "weekday": "Thu",
+        "day": "27",
+        "month": "Aug",
+        "year": "2026",
+        "begin_time": "5:00 PM",
+        "end_time": "9:00 PM",
+        "publish_date": "2026-05-26",
+        "sponsor": "Thomas Jefferson Center for the Study of Core Texts and Ideas",
+        "image": null,
+        "image_caption": "Professor Devin Stauffer at a lectern",
+        "image_path": "event_images/6/61021/opening_lecture.jpg",
+        "full_image_path": "https://minio.la.utexas.edu/colaweb-prod/event_images/6/61021/opening_lecture.jpg",
+        "slug": "opening-lecture-with-professor-devin-stauffer-nbsp-reading-the-great-books-in-the-age-of-ai-2"
+      }
+    },
+    {
+      "type": "events",
+      "id": "61023",
+      "attributes": {
+        "title": "Talk:&nbsp;Alexandra Clark",
+        "summary": null,
+        "body_content": null,
+        "location": null,
+        "date": "Friday August 28, 2026",
+        "weekday": "Fri",
+        "day": "28",
+        "month": "Aug",
+        "year": "2026",
+        "begin_time": "12:00 PM",
+        "end_time": "1:00 PM",
+        "publish_date": null,
+        "sponsor": null,
+        "image": null,
+        "image_caption": null,
+        "image_path": null,
+        "full_image_path": "https://minio.la.utexas.edu/colaweb-prod/",
+        "slug": "opa-talk-nbsp-alexandra-clark"
+      }
+    }
+  ]
+}

--- a/server/src/scrapers/liberalArts.ts
+++ b/server/src/scrapers/liberalArts.ts
@@ -1,0 +1,377 @@
+// College of Liberal Arts scraper: liberalarts.utexas.edu/news-events/events.html.
+//
+// The listing is rendered client-side from COLA's public JSON:API. The API
+// provides full event records and pagination links, so scraping it directly is
+// both more complete and less brittle than parsing the empty HTML shell.
+//
+// Source-specific details:
+//   - Dates and times arrive as separate display strings with no UTC offset.
+//     We combine them and attach the correct America/Chicago DST offset.
+//   - The API exposes a sponsor but no topical tags. When present, the sponsor
+//     becomes both the host organization and the event's source category.
+//   - full_image_path is populated with the bucket root even when an event has
+//     no image, so image_path is the authoritative "has image" signal.
+//   - Descriptions, titles, sponsors, and captions may contain HTML entities;
+//     descriptions may additionally contain full HTML fragments.
+//
+// Dedup key: the API's stable numeric event id.
+
+import { ingestEvents } from '../events/ingest';
+import {
+  classifyAspectRatio,
+  fetchImageMeta,
+  stripHtml,
+  truncateLocation,
+} from '../events/normalize';
+import { fetchWithRetry, sleep } from '../events/polite-fetch';
+import type { NormalizedEvent } from '../events/types';
+import type { Env } from '../worker';
+
+const BASE_URL = 'https://liberalarts.utexas.edu';
+// Explicit page parameters make the API return JSON:API pagination metadata.
+// The public page uses the same division filter to show college-wide events.
+const API_URL =
+  'https://webeditor.la.utexas.edu/api/v2/events?filter%5Bdivision%5D=public-affairs&sort=date&page%5Bnumber%5D=1&page%5Bsize%5D=15';
+export const SOURCE = 'cola';
+
+const REQUEST_DELAY_MS = 200;
+const DEFAULT_MAX_EVENTS = 500;
+const DEFAULT_ORG_NAME = 'College of Liberal Arts';
+// Guards against a malformed or cyclic `links.next` chain.
+const MAX_PAGES = 100;
+
+// Only fields consumed by the scraper are modeled. The API also returns
+// presentation-only fields such as weekday, formatted date, and publish date.
+interface ColaEventAttributes {
+  title: string;
+  summary: string | null;
+  body_content: string | null;
+  location: string | null;
+  day: string;
+  month: string;
+  year: string;
+  begin_time: string | null;
+  end_time: string | null;
+  sponsor: string | null;
+  image_caption: string | null;
+  image_path: string | null;
+  full_image_path: string | null;
+  slug: string;
+}
+
+export interface ColaApiEvent {
+  // Stable database id assigned by COLA's web editor.
+  id: string;
+  attributes: ColaEventAttributes;
+}
+
+// Minimal JSON:API collection shape needed for discovery.
+interface ColaApiResponse {
+  data: ColaApiEvent[];
+  links?: {
+    next?: string | null;
+  };
+}
+
+interface ScraperResult {
+  eventsProcessed: number;
+  eventsUpserted: number;
+  eventsSkipped: number;
+  errors: string[];
+  durationMs: number;
+}
+
+const MONTHS: Record<string, number> = {
+  Jan: 1,
+  Feb: 2,
+  Mar: 3,
+  Apr: 4,
+  May: 5,
+  Jun: 6,
+  Jul: 7,
+  Aug: 8,
+  Sep: 9,
+  Oct: 10,
+  Nov: 11,
+  Dec: 12,
+};
+
+const HTML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: "'",
+  auml: 'ä',
+  gt: '>',
+  ldquo: '“',
+  lsquo: '‘',
+  lt: '<',
+  mdash: '—',
+  nbsp: ' ',
+  ndash: '–',
+  ntilde: 'ñ',
+  oacute: 'ó',
+  quot: '"',
+  rdquo: '”',
+  rsquo: '’',
+};
+
+// COLA content contains both named entities and numeric Unicode entities.
+// Unknown named entities are preserved instead of silently dropping content.
+export function decodeHtmlEntities(text: string): string {
+  return text.replace(/&(#x[\da-f]+|#\d+|[a-z]+);/gi, (entity, code: string) => {
+    if (code.startsWith('#x')) {
+      return String.fromCodePoint(parseInt(code.slice(2), 16));
+    }
+    if (code.startsWith('#')) {
+      return String.fromCodePoint(parseInt(code.slice(1), 10));
+    }
+    return HTML_ENTITIES[code.toLowerCase()] ?? entity;
+  });
+}
+
+// Decode entities before stripping tags so encoded markup remains ordinary
+// text. Returning null for empty content matches the shared D1 event schema.
+function cleanText(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const cleaned = stripHtml(decodeHtmlEntities(value));
+  return cleaned || null;
+}
+
+// COLA currently emits 12-hour values such as "12:00 PM". A strict parser
+// makes unexpected upstream formats fail one event instead of inventing a time.
+function parseTime(value: string | null): { hour: number; minute: number } | null {
+  if (!value) return null;
+  const match = value.trim().match(/^(\d{1,2}):(\d{2})\s*([AP]M)$/i);
+  if (!match) return null;
+
+  let hour = Number(match[1]) % 12;
+  if (match[3].toUpperCase() === 'PM') hour += 12;
+  return { hour, minute: Number(match[2]) };
+}
+
+// Calculate a DST boundary without relying on the Worker's host timezone.
+function nthSunday(year: number, month: number, occurrence: number): number {
+  const firstWeekday = new Date(Date.UTC(year, month - 1, 1)).getUTCDay();
+  return 1 + ((7 - firstWeekday) % 7) + (occurrence - 1) * 7;
+}
+
+// America/Chicago is UTC-5 from the second Sunday in March until the first
+// Sunday in November, and UTC-6 otherwise. COLA events are campus events, so
+// America/Chicago is the source timezone even if the Worker runs in UTC.
+export function centralUtcOffset(year: number, month: number, day: number): string {
+  const dstStart = nthSunday(year, 3, 2);
+  const dstEnd = nthSunday(year, 11, 1);
+  const isDst =
+    (month > 3 && month < 11) || (month === 3 && day >= dstStart) || (month === 11 && day < dstEnd);
+  return isDst ? '-05:00' : '-06:00';
+}
+
+// Combine the API's separate date fields and display time into an ISO-8601
+// datetime suitable for D1 and the React Native client.
+function buildDatetime(attributes: ColaEventAttributes, timeValue: string | null): string | null {
+  const year = Number(attributes.year);
+  const month = MONTHS[attributes.month];
+  const day = Number(attributes.day);
+  const time = parseTime(timeValue);
+
+  if (!year || !month || !day || !time) return null;
+
+  const pad = (value: number) => String(value).padStart(2, '0');
+  const datetime = `${year}-${pad(month)}-${pad(day)}T${pad(time.hour)}:${pad(time.minute)}:00${centralUtcOffset(year, month, day)}`;
+  return Number.isNaN(new Date(datetime).getTime()) ? null : datetime;
+}
+
+// Category ids must be deterministic across runs; names remain human-readable.
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Map one JSON:API record into the shared ingestion shape.
+ *
+ * This function is intentionally pure and synchronous so fixtures can cover
+ * source parsing without network or D1 dependencies. Image dimensions and MIME
+ * type are added later because they require a range request to the image.
+ */
+export function parseApiEvent(event: ColaApiEvent, now = Date.now()): NormalizedEvent | null {
+  const attributes = event.attributes;
+  const title = cleanText(attributes.title);
+  const startDatetime = buildDatetime(attributes, attributes.begin_time);
+  if (!event.id || !title || !startDatetime || !attributes.slug) return null;
+
+  const endDatetime = buildDatetime(attributes, attributes.end_time);
+  const endMs = new Date(endDatetime ?? startDatetime).getTime();
+  // Keep an in-progress event until its end time. With no end time, the start
+  // time is the best available cutoff.
+  if (endMs < now) return null;
+
+  const locationFull = cleanText(attributes.location);
+  const sponsor = cleanText(attributes.sponsor);
+  const organizationName = sponsor ?? DEFAULT_ORG_NAME;
+  // The bucket root alone is not an event image; image_path distinguishes it.
+  const imageUrl = attributes.image_path ? attributes.full_image_path : null;
+  const eventUrl = `${BASE_URL}/events/${attributes.slug}`;
+
+  return {
+    source: SOURCE,
+    sourceEventId: event.id,
+    title,
+    description: cleanText(attributes.summary) ?? cleanText(attributes.body_content),
+    startDatetime,
+    endDatetime,
+    locationShort: truncateLocation(locationFull),
+    locationFull,
+    latitude: null,
+    longitude: null,
+    organization: {
+      sourceOrgId: null,
+      name: organizationName,
+      profilePicture: null,
+    },
+    eventUrl,
+    rsvpUrl: null,
+    imageUrl,
+    imageWidth: null,
+    imageHeight: null,
+    // Replaced with header-derived classification during orchestration.
+    imageAspectRatio: imageUrl ? 'square' : 'none',
+    imageMimeType: null,
+    imageAltText: imageUrl ? (cleanText(attributes.image_caption) ?? title) : null,
+    theme: null,
+    visibility: 'Public',
+    rsvpTotal: 0,
+    // COLA exposes organizational sponsorship, but no topical categories.
+    categories: sponsor ? [{ id: `sponsor-${slugify(sponsor)}`, name: sponsor }] : [],
+    benefits: [],
+  };
+}
+
+export function getNextPageUrl(payload: ColaApiResponse): string | null {
+  return payload.links?.next ?? null;
+}
+
+/**
+ * Follow the API-provided next links and deduplicate records by stable id.
+ *
+ * A Map protects against overlapping pages if new events are published while a
+ * scrape is in progress. The returned order remains the API's date order.
+ */
+export async function discoverApiEvents(): Promise<ColaApiEvent[]> {
+  const events = new Map<string, ColaApiEvent>();
+  let pageUrl: string | null = API_URL;
+
+  for (let page = 0; page < MAX_PAGES && pageUrl; page++) {
+    const res = await fetchWithRetry(pageUrl, { headers: { Accept: '*/*' } });
+    const payload = (await res.json()) as ColaApiResponse;
+    // Treat a changed response shape as a discovery failure. Continuing with a
+    // partial run would undermine the scraper's coverage guarantee.
+    if (!Array.isArray(payload.data)) {
+      throw new Error(`Invalid API response on page ${page + 1}`);
+    }
+
+    for (const event of payload.data) {
+      if (event?.id && event.attributes) events.set(event.id, event);
+    }
+
+    pageUrl = getNextPageUrl(payload);
+    if (pageUrl) await sleep(REQUEST_DELAY_MS);
+  }
+
+  return [...events.values()];
+}
+
+/**
+ * Discover, normalize, enrich, and ingest one COLA scrape run.
+ *
+ * Discovery failures stop the run because completeness is unknown. Once the
+ * collection is available, each event is isolated so malformed content or a
+ * failed image request cannot prevent other records from reaching D1.
+ */
+export async function scrapeLiberalArts(
+  env: Env,
+  options: { maxEvents?: number; dryRun?: boolean } = {},
+): Promise<ScraperResult> {
+  const dryRun = options.dryRun ?? false;
+  const maxEvents = options.maxEvents ?? DEFAULT_MAX_EVENTS;
+  const t0 = Date.now();
+
+  const errors: string[] = [];
+  let eventsProcessed = 0;
+  let eventsUpserted = 0;
+  let eventsSkipped = 0;
+
+  let apiEvents: ColaApiEvent[];
+  try {
+    apiEvents = await discoverApiEvents();
+  } catch (err) {
+    const msg = `Fatal error discovering events: ${err}`;
+    console.error(`[liberalArts] ${msg}`);
+    return {
+      eventsProcessed: 0,
+      eventsUpserted: 0,
+      eventsSkipped: 0,
+      errors: [msg],
+      durationMs: Date.now() - t0,
+    };
+  }
+
+  console.log(`[liberalArts] Discovered ${apiEvents.length} events`);
+  const normalized: NormalizedEvent[] = [];
+  const now = Date.now();
+
+  for (const apiEvent of apiEvents.slice(0, maxEvents)) {
+    eventsProcessed++;
+    try {
+      const parsed = parseApiEvent(apiEvent, now);
+      if (!parsed) {
+        eventsSkipped++;
+        continue;
+      }
+
+      if (parsed.imageUrl) {
+        // Range-read only the image header; full flyer downloads are unnecessary.
+        const meta = await fetchImageMeta(parsed.imageUrl, 'liberalArts');
+        parsed.imageWidth = meta.width;
+        parsed.imageHeight = meta.height;
+        parsed.imageMimeType = meta.mimeType;
+        parsed.imageAspectRatio = classifyAspectRatio(meta.width, meta.height, true, 0.05);
+        await sleep(REQUEST_DELAY_MS);
+      }
+
+      if (dryRun) {
+        console.log(`[DRY RUN] "${parsed.title}" (${parsed.sourceEventId})`);
+      } else {
+        normalized.push(parsed);
+      }
+    } catch (err) {
+      const msg = `Failed to process event ${apiEvent.id}: ${err}`;
+      console.error(`[liberalArts] ${msg}`);
+      errors.push(msg);
+    }
+  }
+
+  if (!dryRun && normalized.length > 0) {
+    // Shared ingestion performs the (source, source_event_id) upsert and
+    // isolates D1 errors per event.
+    const result = await ingestEvents(env, normalized);
+    eventsUpserted = result.inserted + result.updated;
+    errors.push(...result.errors);
+  }
+
+  const durationMs = Date.now() - t0;
+  console.log(
+    `[liberalArts] Finished in ${(durationMs / 1000).toFixed(1)}s — ${eventsUpserted} upserted, ${eventsSkipped} skipped, ${errors.length} errors`,
+  );
+
+  return { eventsProcessed, eventsUpserted, eventsSkipped, errors, durationMs };
+}
+
+// Scheduled Worker entrypoint used by the central scraper registry.
+export async function run(env: Env): Promise<void> {
+  console.log('[liberalArts] Scraper started');
+  await scrapeLiberalArts(env);
+}

--- a/server/src/scrapers/registry.ts
+++ b/server/src/scrapers/registry.ts
@@ -14,6 +14,7 @@ import { run as runFineArts, scrapeFineArts } from './finearts';
 import { run as runCns } from './cns';
 import { run as runHornsLink, scrapeHornsLink } from './hornslink';
 import { run as runLawSchool, scrapeLawSchool } from './lawSchool';
+import { run as runLiberalArts, scrapeLiberalArts } from './liberalArts';
 import { run as runMccombs, scrapeMccombs } from './mccombs';
 import { run as runTexasGlobal, scrapeTexasGlobal } from './texasGlobal';
 import { run as runTexasToday } from './texasToday';
@@ -31,6 +32,7 @@ export const SCRAPERS: ScraperEntry[] = [
   { name: 'mccombs', run: runMccombs, manual: scrapeMccombs },
   { name: 'texasGlobal', run: runTexasGlobal, manual: scrapeTexasGlobal },
   { name: 'lawSchool', run: runLawSchool, manual: scrapeLawSchool },
+  { name: 'cola', run: runLiberalArts, manual: scrapeLiberalArts },
   { name: 'cockrell', run: runCockrell, manual: scrapeCockrell },
   { name: 'cofa', run: runFineArts, manual: scrapeFineArts },
   { name: 'cns', run: runCns },

--- a/server/test/scrapers/test_liberalArts.ts
+++ b/server/test/scrapers/test_liberalArts.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  centralUtcOffset,
+  decodeHtmlEntities,
+  getNextPageUrl,
+  parseApiEvent,
+  type ColaApiEvent,
+} from '../../src/scrapers/liberalArts';
+
+interface Fixture {
+  data: ColaApiEvent[];
+  links?: { next?: string };
+}
+
+function loadFixture(name: string): Fixture {
+  return JSON.parse(
+    readFileSync(
+      join(__dirname, '..', '..', 'src', 'scrapers', '__fixtures__', 'liberalArts', name),
+      'utf-8',
+    ),
+  ) as Fixture;
+}
+
+const NOW = new Date('2026-01-01T00:00:00Z').getTime();
+
+describe('parseApiEvent', () => {
+  const events = loadFixture('listing-page.json').data;
+
+  it('maps all fields from a sponsored event with an image', () => {
+    const parsed = parseApiEvent(events[0], NOW);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.source).toBe('cola');
+    expect(parsed?.sourceEventId).toBe('61021');
+    expect(parsed?.title).toBe(
+      'Opening Lecture with Professor Devin Stauffer, "Reading the Great Books in the Age of AI"',
+    );
+    expect(parsed?.description).toBe(
+      'This lecture will be followed by a Pizza and Pool party at the Outdoor Rec Pool at Gregory Gym.',
+    );
+    expect(parsed?.startDatetime).toBe('2026-08-27T17:00:00-05:00');
+    expect(parsed?.endDatetime).toBe('2026-08-27T21:00:00-05:00');
+    expect(parsed?.locationShort).toBe('Avaya Auditorium POB 2.302');
+    expect(parsed?.organization.name).toBe(
+      'Thomas Jefferson Center for the Study of Core Texts and Ideas',
+    );
+    expect(parsed?.eventUrl).toBe(
+      'https://liberalarts.utexas.edu/events/opening-lecture-with-professor-devin-stauffer-nbsp-reading-the-great-books-in-the-age-of-ai-2',
+    );
+    expect(parsed?.imageUrl).toBe(
+      'https://minio.la.utexas.edu/colaweb-prod/event_images/6/61021/opening_lecture.jpg',
+    );
+    expect(parsed?.imageAltText).toBe('Professor Devin Stauffer at a lectern');
+    expect(parsed?.categories).toEqual([
+      {
+        id: 'sponsor-thomas-jefferson-center-for-the-study-of-core-texts-and-ideas',
+        name: 'Thomas Jefferson Center for the Study of Core Texts and Ideas',
+      },
+    ]);
+  });
+
+  it('handles missing optional fields without treating the image base URL as an image', () => {
+    const parsed = parseApiEvent(events[1], NOW);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.title).toBe('Talk: Alexandra Clark');
+    expect(parsed?.description).toBeNull();
+    expect(parsed?.locationShort).toBeNull();
+    expect(parsed?.organization.name).toBe('College of Liberal Arts');
+    expect(parsed?.imageUrl).toBeNull();
+    expect(parsed?.imageAspectRatio).toBe('none');
+    expect(parsed?.categories).toEqual([]);
+  });
+
+  it('uses summary before body content', () => {
+    const event = loadFixture('last-page.json').data[0];
+    const parsed = parseApiEvent(event, NOW);
+    expect(parsed?.description).toBe('A discussion of the Constitution.');
+  });
+
+  it('skips ended and malformed events', () => {
+    expect(parseApiEvent(events[0], new Date('2027-01-01T00:00:00Z').getTime())).toBeNull();
+    expect(
+      parseApiEvent(
+        { ...events[0], attributes: { ...events[0].attributes, begin_time: null } },
+        NOW,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe('pagination', () => {
+  it('follows the next link and stops on the last page', () => {
+    expect(getNextPageUrl(loadFixture('listing-page.json'))).toContain('page%5Bnumber%5D=2');
+    expect(getNextPageUrl(loadFixture('last-page.json'))).toBeNull();
+  });
+});
+
+describe('centralUtcOffset', () => {
+  it('uses standard and daylight-saving offsets at the US Central boundaries', () => {
+    expect(centralUtcOffset(2026, 1, 15)).toBe('-06:00');
+    expect(centralUtcOffset(2026, 3, 7)).toBe('-06:00');
+    expect(centralUtcOffset(2026, 3, 8)).toBe('-05:00');
+    expect(centralUtcOffset(2026, 11, 1)).toBe('-06:00');
+  });
+});
+
+describe('decodeHtmlEntities', () => {
+  it('decodes named, decimal, and hexadecimal entities', () => {
+    expect(decodeHtmlEntities('A&amp;M &#8212; M&#xFC;ller')).toBe('A&M — Müller');
+  });
+});


### PR DESCRIPTION
## Summary

Closes LOOP-233.

Adds a Cloudflare Worker scraper for the College of Liberal Arts events page:

https://liberalarts.utexas.edu/news-events/events.html

The public page renders events client-side, so the scraper uses the same paginated JSON API that powers the COLA website rather than parsing the empty HTML shell.

## Implementation

- Added `server/src/scrapers/liberalArts.ts`.
- Registered the `cola` scraper in the central scraper registry.
- Added a scheduled `run()` entrypoint and manual scraper support.
- Follows the API-provided pagination links until the final page.
- Deduplicates discovered records using COLA's stable numeric event IDs.
- Uses `source = "cola"` and the numeric API ID as `source_event_id`.
- Maps events into the shared D1 ingestion schema.
- Uses the shared ingestion layer to upsert on `(source, source_event_id)`.
- Isolates parsing, image metadata, and D1 failures per event.

## Extracted Fields

The scraper maps:

- Title
- Description
- Start datetime
- End datetime
- Short and full location
- Host organization
- Event URL
- Image URL
- Image width and height
- Image MIME type
- Image alt text
- Image aspect ratio
- Source categories

COLA provides organizational sponsors but does not expose topical event tags. When present, the sponsor is used as the host organization and as a deterministic source category. Events without a sponsor fall back to `College of Liberal Arts`.

## Date and Time Handling

COLA returns separate date and 12-hour time fields without a timezone offset.

The scraper:

- Parses the abbreviated month values returned by the API.
- Converts times into ISO-8601 datetimes.
- Applies the appropriate `America/Chicago` standard or daylight-saving offset.
- Keeps in-progress events until their end time.
- Skips malformed or already-ended events without stopping the remaining run.

## Image Handling

COLA populates `full_image_path` with the storage bucket root even when an event has no image. The scraper therefore treats `image_path` as the authoritative image-presence field.

For valid images, it range-reads the image header to determine:

- Width
- Height
- MIME type
- `vertical`, `square`, or `horizontal` aspect ratio

Events without images receive an aspect ratio of `none`.

## Pagination and Reliability

- Uses explicit JSON API page parameters.
- Follows `links.next` instead of assuming a fixed number of pages.
- Applies a safety limit to prevent cyclic pagination.
- Deduplicates overlapping pages with a map keyed by event ID.
- Uses retries and polite delays between requests.
- Stops on collection-level discovery failures to avoid silently ingesting an incomplete run.
- Continues processing when an individual event or image fails.

The COLA API requires `Accept: */*`; requesting `application/json` returns HTTP 406.

## Tests

Added saved JSON API fixtures covering:

- Paginated responses
- Final-page detection
- Sponsored events
- Missing optional fields
- Events with and without images
- Description fallbacks
- HTML entity decoding
- Central-time DST offsets
- Ended and malformed event filtering

## Verification

- COLA scraper tests: 7 passed
- Full server test suite: 123 passed
- Server TypeScript build passed
- Repository TypeScript check passed
- ESLint passed
- Prettier passed
- Live API smoke test discovered 20 events and successfully parsed all 20 before elapsed-event filtering