### PR TITLE
feat(scraper): add Moody College events scraper (LOOP-229)

### DIFF
--- a/server/src/scrapers/__fixtures__/moody/detail-page.html
+++ b/server/src/scrapers/__fixtures__/moody/detail-page.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html>
+  <head>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@graph": [
+          {
+            "@type": "Event",
+            "url": "https://events.moody.utexas.edu/events/student-screenwriting-festival",
+            "name": "Student Screenwriting Festival",
+            "image": {
+              "@type": "ImageObject",
+              "url": "https://events.moody.utexas.edu/sites/default/files/styles/large/public/2027-03/festival.png?itok=abc",
+              "width": "480",
+              "height": "480"
+            },
+            "description": "A two-day festival for student filmmakers and writers.",
+            "eventStatus": "EventScheduled",
+            "startDate": "2027-03-25T17:00:00-05:00",
+            "endDate": "2027-03-25T20:00:00-05:00",
+            "location": { "@type": "Place", "name": "CMB Studio 4C" }
+          }
+        ]
+      }
+    </script>
+  </head>
+  <body>
+    <article class="node node--type-utevent-event">
+      <div class="event-image-wrapper">
+        <img
+          class="img-fluid"
+          src="/sites/default/files/2027-03/festival.png"
+          alt="Students discussing screenplays"
+        />
+      </div>
+      <div class="event-body"><p>Festival description.</p></div>
+      <div id="details">
+        <!-- prettier-ignore -->
+        <p>
+            <strong>Event Categories:</strong>
+            Guest Speaker
+            Panel Discussion
+            Screening
+            Social
+          </p>
+        <p><strong>Location:</strong> CMB 4.122 Studio 4C</p>
+        <p>
+          <strong>Website:</strong>
+          <a href="https://example.com/register">RSVP for more details!</a>
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/server/src/scrapers/__fixtures__/moody/last-page.html
+++ b/server/src/scrapers/__fixtures__/moody/last-page.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <body>
+    <div class="views-row">
+      <div class="views-field views-field-custom-event-field">
+        <span class="field-content">
+          <div class="card-link moody-custom-event-card">
+            <div class="card hover-effect">
+              <h3 class="event-title"><a href="/events/no-flyer-workshop">No Flyer Workshop</a></h3>
+              <h5 class="card-title">Workshop</h5>
+              <p class="card-text">A practical communication workshop.</p>
+              <div class="card-subtitle">April 2nd, 2027 - 12:00 pm</div>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+  </body>
+</html>

--- a/server/src/scrapers/__fixtures__/moody/listing-page.html
+++ b/server/src/scrapers/__fixtures__/moody/listing-page.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+  <body>
+    <div class="views-row">
+      <div class="views-field views-field-custom-event-field">
+        <span class="field-content">
+          <div class="card-link moody-custom-event-card">
+            <div class="card hover-effect">
+              <div class="row">
+                <div class="col-md-7 title-category-column">
+                  <div class="row title-column">
+                    <h3 class="event-title">
+                      <a href="/events/student-screenwriting-festival"
+                        >Student Screenwriting Festival</a
+                      >
+                    </h3>
+                  </div>
+                  <div class="row title-column mobile-padding category-row">
+                    <h5 class="card-title">Screening</h5>
+                  </div>
+                  <div class="row">
+                    <div class="col-12">
+                      <p class="card-text">
+                        A two-day festival for student filmmakers &amp; writers.
+                      </p>
+                      <div class="card-text">
+                        <div class="card-subtitle">March 25th, 2027 - 5:00 pm</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="col-md-4 image-column">
+                  <a href="/events/student-screenwriting-festival">
+                    <img
+                      src="/sites/default/files/styles/large/public/2027-03/festival.png?itok=abc"
+                      class="card-img-top"
+                      alt="Event image"
+                    />
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </span>
+      </div>
+    </div>
+    <ul class="pager__items js-pager__items">
+      <li class="pager__item pager__item--next">
+        <a href="?page=1" title="Go to next page" rel="next">Next</a>
+      </li>
+    </ul>
+  </body>
+</html>

--- a/server/src/scrapers/moody.ts
+++ b/server/src/scrapers/moody.ts
@@ -29,6 +29,8 @@ interface ScraperResult {
 }
 
 export interface MoodyListingEvent {
+  // Drupal reuses one node URL for every occurrence of a recurring event.
+  // `startDatetime` must therefore be part of the eventual dedupe key.
   slug: string;
   title: string;
   description: string | null;
@@ -85,6 +87,9 @@ export function normalizeHtml(html: string): string {
     .replace(/> </g, '><');
 }
 
+// Each Drupal Views result starts with views-row, but the nested card has no
+// convenient unique closing tag. Splitting on the next row marker tolerates
+// optional card fields and changes in nesting depth.
 export function extractEventCards(html: string): string[] {
   return normalizeHtml(html)
     .split('<div class="views-row">')
@@ -97,6 +102,8 @@ export function hasNextPage(html: string): boolean {
 }
 
 function chicagoOffset(date: string): string {
+  // Listing dates have no offset. Resolve it for the event date rather than
+  // assuming CST or CDT, since one scrape can span a DST boundary.
   const parts = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/Chicago',
     timeZoneName: 'shortOffset',
@@ -169,6 +176,8 @@ export function parseListingCard(cardHtml: string): MoodyListingEvent | null {
   };
 }
 
+// A page can contain unrelated JSON-LD blocks. Scan until an Event node is
+// found and ignore malformed or non-event blocks.
 export function extractSchemaEvent(html: string): SchemaEvent | null {
   const scripts = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
   for (const script of scripts) {
@@ -196,6 +205,8 @@ function extractLabeledValue(html: string, label: string): string | null {
 export function extractCategories(detailHtml: string): string[] {
   const match = detailHtml.match(/<strong>Event Categories:<\/strong>([\s\S]*?)<\/p>/i);
   if (!match) return [];
+  // Moody renders taxonomy values as separate text lines without commas or
+  // wrapping elements. Preserve those lines or distinct names merge together.
   return match[1]
     .split(/\r?\n/)
     .map((line) => textContent(line))
@@ -246,6 +257,8 @@ export function parseMoodyEvent(
   const schema = extractSchemaEvent(detailHtml);
   let endDatetime: string | null = null;
   if (schema?.startDate && schema.endDate) {
+    // Recurring nodes describe their first occurrence in JSON-LD even when the
+    // listing points to a later one. Reuse the duration, not the stale start.
     const duration = new Date(schema.endDate).getTime() - new Date(schema.startDate).getTime();
     if (Number.isFinite(duration) && duration >= 0) {
       endDatetime =
@@ -273,6 +286,7 @@ export function parseMoodyEvent(
 
   return {
     source: SOURCE,
+    // Slugs repeat across occurrences; slug + start is stable across reruns.
     sourceEventId: `${listing.slug}::${listing.startDatetime}`,
     title: schema?.name?.trim() || listing.title,
     description: schema?.description?.trim() || listing.description,
@@ -302,6 +316,7 @@ export function parseMoodyEvent(
   };
 }
 
+// The cap guards against a malformed pager producing an infinite Worker run.
 export async function discoverEventCards(): Promise<string[]> {
   const cards: string[] = [];
   for (let page = 0; page < MAX_PAGES; page++) {
@@ -355,6 +370,8 @@ export async function scrapeMoody(
         const res = await fetchWithRetry(listing.eventUrl, { headers: { Accept: '*/*' } });
         detailHtml = await res.text();
       } catch (err) {
+        // The listing still provides enough data for a useful partial record,
+        // so one failed detail request must not drop the event.
         console.warn(`[moody] Failed to fetch detail page ${listing.eventUrl}: ${err}`);
       }
 
@@ -365,6 +382,8 @@ export async function scrapeMoody(
       }
 
       if (parsed.imageUrl && (!parsed.imageWidth || !parsed.imageHeight)) {
+        // JSON-LD usually provides dimensions. Only range-read the image when
+        // that metadata is absent.
         const meta = await fetchImageMeta(parsed.imageUrl, 'moody');
         parsed.imageWidth = meta.width;
         parsed.imageHeight = meta.height;

--- a/server/src/scrapers/moody.ts
+++ b/server/src/scrapers/moody.ts
@@ -1,0 +1,407 @@
+// Moody College of Communication scraper: events.moody.utexas.edu (Drupal).
+//
+// The paginated listing identifies each upcoming occurrence. Detail pages add
+// Schema.org event data for descriptions, end times, locations, and images.
+// Moody does not render an event's host taxonomy on either page, so events use
+// the college itself as their host organization.
+
+import { ingestEvents } from '../events/ingest';
+import { classifyAspectRatio, fetchImageMeta } from '../events/normalize';
+import { fetchWithRetry, sleep } from '../events/polite-fetch';
+import type { NormalizedEvent } from '../events/types';
+import type { Env } from '../worker';
+
+const BASE_URL = 'https://events.moody.utexas.edu';
+const LISTING_URL = `${BASE_URL}/upcoming-events`;
+export const SOURCE = 'moody';
+
+const DEFAULT_ORG_NAME = 'Moody College of Communication';
+const DEFAULT_MAX_EVENTS = 500;
+const MAX_PAGES = 50;
+const REQUEST_DELAY_MS = 200;
+
+interface ScraperResult {
+  eventsProcessed: number;
+  eventsUpserted: number;
+  eventsSkipped: number;
+  errors: string[];
+  durationMs: number;
+}
+
+export interface MoodyListingEvent {
+  slug: string;
+  title: string;
+  description: string | null;
+  startDatetime: string;
+  eventUrl: string;
+  imageUrl: string | null;
+  categories: string[];
+}
+
+interface SchemaImage {
+  url?: string;
+  width?: string | number;
+  height?: string | number;
+}
+
+interface SchemaPlace {
+  name?: string;
+  address?: string | Record<string, string>;
+}
+
+interface SchemaEvent {
+  '@type'?: string | string[];
+  name?: string;
+  description?: string;
+  startDate?: string;
+  endDate?: string;
+  image?: string | SchemaImage;
+  location?: string | SchemaPlace;
+}
+
+export function decodeHtmlEntities(text: string): string {
+  return text
+    .replace(/&#x([0-9a-f]+);/gi, (_, code: string) => String.fromCodePoint(parseInt(code, 16)))
+    .replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number(code)))
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;|&#0?39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+function textContent(html: string): string {
+  return decodeHtmlEntities(html.replace(/<[^>]*>/g, ' '))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function normalizeHtml(html: string): string {
+  return html
+    .replace(/\s+/g, ' ')
+    .replace(/\s+>/g, '>')
+    .replace(/<\s+/g, '<')
+    .replace(/> </g, '><');
+}
+
+export function extractEventCards(html: string): string[] {
+  return normalizeHtml(html)
+    .split('<div class="views-row">')
+    .slice(1)
+    .filter((chunk) => chunk.includes('moody-custom-event-card'));
+}
+
+export function hasNextPage(html: string): boolean {
+  return /rel="next"/.test(html);
+}
+
+function chicagoOffset(date: string): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Chicago',
+    timeZoneName: 'shortOffset',
+  }).formatToParts(new Date(`${date}T12:00:00Z`));
+  const match = parts.find((part) => part.type === 'timeZoneName')?.value.match(/GMT([+-]\d+)/);
+  const hours = match ? Number(match[1]) : -6;
+  return `${hours >= 0 ? '+' : '-'}${String(Math.abs(hours)).padStart(2, '0')}:00`;
+}
+
+const MONTHS: Record<string, number> = {
+  january: 1,
+  february: 2,
+  march: 3,
+  april: 4,
+  may: 5,
+  june: 6,
+  july: 7,
+  august: 8,
+  september: 9,
+  october: 10,
+  november: 11,
+  december: 12,
+};
+
+// "March 24th, 2026 - 10:00 am" -> a DST-aware ISO datetime.
+export function parseListingDatetime(value: string): string | null {
+  const match = value
+    .trim()
+    .match(/^([A-Za-z]+)\s+(\d{1,2})(?:st|nd|rd|th),\s+(\d{4})\s+-\s+(\d{1,2}):(\d{2})\s*([ap]m)/i);
+  if (!match) return null;
+
+  const month = MONTHS[match[1].toLowerCase()];
+  if (!month) return null;
+  let hour = Number(match[4]) % 12;
+  if (match[6].toLowerCase() === 'pm') hour += 12;
+  const date = `${match[3]}-${String(month).padStart(2, '0')}-${match[2].padStart(2, '0')}`;
+  return `${date}T${String(hour).padStart(2, '0')}:${match[5]}:00${chicagoOffset(date)}`;
+}
+
+function absoluteUrl(path: string): string {
+  return path.startsWith('http') ? path : `${BASE_URL}${path}`;
+}
+
+export function parseListingCard(cardHtml: string): MoodyListingEvent | null {
+  const card = normalizeHtml(cardHtml);
+  const titleMatch = card.match(/<h3 class="event-title"><a href="([^"]+)">([\s\S]*?)<\/a><\/h3>/);
+  if (!titleMatch) return null;
+
+  const eventUrl = absoluteUrl(decodeHtmlEntities(titleMatch[1]));
+  const slugMatch = new URL(eventUrl).pathname.match(/^\/events\/([^/]+)\/?$/);
+  if (!slugMatch) return null;
+
+  const dateMatch = card.match(/<div class="card-subtitle">([\s\S]*?)<\/div>/);
+  const startDatetime = dateMatch ? parseListingDatetime(textContent(dateMatch[1])) : null;
+  if (!startDatetime) return null;
+
+  const descriptionMatch = card.match(/<p class="card-text">([\s\S]*?)<\/p>/);
+  const imageMatch = card.match(/<img\b[^>]*\bsrc="([^"]+)"/);
+  const categoryMatch = card.match(/<h5 class="card-title">([\s\S]*?)<\/h5>/);
+  const category = categoryMatch ? textContent(categoryMatch[1]) : '';
+
+  return {
+    slug: slugMatch[1],
+    title: textContent(titleMatch[2]),
+    description: descriptionMatch ? textContent(descriptionMatch[1]) || null : null,
+    startDatetime,
+    eventUrl,
+    imageUrl: imageMatch ? absoluteUrl(decodeHtmlEntities(imageMatch[1])) : null,
+    categories: category ? [category] : [],
+  };
+}
+
+export function extractSchemaEvent(html: string): SchemaEvent | null {
+  const scripts = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+  for (const script of scripts) {
+    try {
+      const json = JSON.parse(script[1]) as SchemaEvent & { '@graph'?: SchemaEvent[] };
+      const candidates: SchemaEvent[] = Array.isArray(json['@graph']) ? json['@graph'] : [json];
+      const event = candidates.find((item) => {
+        const type = item['@type'];
+        return type === 'Event' || (Array.isArray(type) && type.includes('Event'));
+      });
+      if (event) return event;
+    } catch {
+      // Other JSON-LD blocks should not prevent parsing the event block.
+    }
+  }
+  return null;
+}
+
+function extractLabeledValue(html: string, label: string): string | null {
+  const match = html.match(new RegExp(`<strong>${label}:<\\/strong>([\\s\\S]*?)<\\/p>`, 'i'));
+  if (!match) return null;
+  return textContent(match[1]) || null;
+}
+
+export function extractCategories(detailHtml: string): string[] {
+  const match = detailHtml.match(/<strong>Event Categories:<\/strong>([\s\S]*?)<\/p>/i);
+  if (!match) return [];
+  return match[1]
+    .split(/\r?\n/)
+    .map((line) => textContent(line))
+    .filter(Boolean);
+}
+
+function categoryId(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function schemaLocation(location: SchemaEvent['location']): string | null {
+  if (typeof location === 'string') return location.trim() || null;
+  if (!location) return null;
+  if (typeof location.address === 'string') {
+    return [location.name, location.address].filter(Boolean).join(', ') || null;
+  }
+  const address = location.address
+    ? [
+        location.address.streetAddress,
+        location.address.addressLocality,
+        location.address.addressRegion,
+        location.address.postalCode,
+      ]
+        .filter(Boolean)
+        .join(', ')
+    : '';
+  return [location.name, address].filter(Boolean).join(', ') || null;
+}
+
+function inferMimeType(url: string | null): string | null {
+  if (!url) return null;
+  const path = url.split('?')[0].toLowerCase();
+  if (path.endsWith('.png')) return 'image/png';
+  if (path.endsWith('.gif')) return 'image/gif';
+  if (path.endsWith('.webp')) return 'image/webp';
+  if (path.endsWith('.jpg') || path.endsWith('.jpeg')) return 'image/jpeg';
+  return null;
+}
+
+export function parseMoodyEvent(
+  listing: MoodyListingEvent,
+  detailHtml: string,
+  now = Date.now(),
+): NormalizedEvent | null {
+  const schema = extractSchemaEvent(detailHtml);
+  let endDatetime: string | null = null;
+  if (schema?.startDate && schema.endDate) {
+    const duration = new Date(schema.endDate).getTime() - new Date(schema.startDate).getTime();
+    if (Number.isFinite(duration) && duration >= 0) {
+      endDatetime =
+        new Date(schema.startDate).getTime() === new Date(listing.startDatetime).getTime()
+          ? schema.endDate
+          : new Date(new Date(listing.startDatetime).getTime() + duration).toISOString();
+    }
+  }
+
+  const endMs = endDatetime
+    ? new Date(endDatetime).getTime()
+    : new Date(listing.startDatetime).getTime();
+  if (!Number.isFinite(endMs) || endMs < now) return null;
+
+  const schemaImage = typeof schema?.image === 'string' ? { url: schema.image } : schema?.image;
+  const imageUrl = schemaImage?.url ? absoluteUrl(schemaImage.url) : listing.imageUrl;
+  const imageWidth = schemaImage?.width ? Number(schemaImage.width) : null;
+  const imageHeight = schemaImage?.height ? Number(schemaImage.height) : null;
+  const categories = extractCategories(detailHtml);
+  const location = extractLabeledValue(detailHtml, 'Location') ?? schemaLocation(schema?.location);
+  const imageAltMatch = detailHtml.match(
+    /<div class="event-image-wrapper">[\s\S]*?<img\b[^>]*\balt="([^"]*)"/,
+  );
+  const websiteMatch = detailHtml.match(/<strong>Website:<\/strong>[\s\S]*?<a href="([^"]+)"/i);
+
+  return {
+    source: SOURCE,
+    sourceEventId: `${listing.slug}::${listing.startDatetime}`,
+    title: schema?.name?.trim() || listing.title,
+    description: schema?.description?.trim() || listing.description,
+    startDatetime: listing.startDatetime,
+    endDatetime,
+    locationShort: location ? location.slice(0, 40) : null,
+    locationFull: location,
+    latitude: null,
+    longitude: null,
+    organization: { sourceOrgId: null, name: DEFAULT_ORG_NAME, profilePicture: null },
+    eventUrl: listing.eventUrl,
+    rsvpUrl: websiteMatch ? absoluteUrl(decodeHtmlEntities(websiteMatch[1])) : null,
+    imageUrl,
+    imageWidth: Number.isFinite(imageWidth) ? imageWidth : null,
+    imageHeight: Number.isFinite(imageHeight) ? imageHeight : null,
+    imageAspectRatio: classifyAspectRatio(imageWidth, imageHeight, Boolean(imageUrl), 0.05),
+    imageMimeType: inferMimeType(imageUrl),
+    imageAltText: imageAltMatch ? decodeHtmlEntities(imageAltMatch[1]).trim() || null : null,
+    theme: null,
+    visibility: 'Public',
+    rsvpTotal: 0,
+    categories: (categories.length > 0 ? categories : listing.categories).map((name) => ({
+      id: categoryId(name),
+      name,
+    })),
+    benefits: [],
+  };
+}
+
+export async function discoverEventCards(): Promise<string[]> {
+  const cards: string[] = [];
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const res = await fetchWithRetry(`${LISTING_URL}?page=${page}`, { headers: { Accept: '*/*' } });
+    const html = await res.text();
+    cards.push(...extractEventCards(html));
+    if (!hasNextPage(html)) break;
+    await sleep(REQUEST_DELAY_MS);
+  }
+  return cards;
+}
+
+export async function scrapeMoody(
+  env: Env,
+  options: { maxEvents?: number; dryRun?: boolean } = {},
+): Promise<ScraperResult> {
+  const t0 = Date.now();
+  const maxEvents = options.maxEvents ?? DEFAULT_MAX_EVENTS;
+  const dryRun = options.dryRun ?? false;
+  const errors: string[] = [];
+  let eventsSkipped = 0;
+  let eventsUpserted = 0;
+
+  let cards: string[];
+  try {
+    cards = await discoverEventCards();
+  } catch (err) {
+    const msg = `Fatal error discovering event listing: ${err}`;
+    console.error(`[moody] ${msg}`);
+    return {
+      eventsProcessed: 0,
+      eventsUpserted: 0,
+      eventsSkipped: 0,
+      errors: [msg],
+      durationMs: Date.now() - t0,
+    };
+  }
+
+  const normalized: NormalizedEvent[] = [];
+  const selectedCards = cards.slice(0, maxEvents);
+  for (const cardHtml of selectedCards) {
+    try {
+      const listing = parseListingCard(cardHtml);
+      if (!listing) {
+        eventsSkipped++;
+        continue;
+      }
+
+      let detailHtml = '';
+      try {
+        const res = await fetchWithRetry(listing.eventUrl, { headers: { Accept: '*/*' } });
+        detailHtml = await res.text();
+      } catch (err) {
+        console.warn(`[moody] Failed to fetch detail page ${listing.eventUrl}: ${err}`);
+      }
+
+      const parsed = parseMoodyEvent(listing, detailHtml);
+      if (!parsed) {
+        eventsSkipped++;
+        continue;
+      }
+
+      if (parsed.imageUrl && (!parsed.imageWidth || !parsed.imageHeight)) {
+        const meta = await fetchImageMeta(parsed.imageUrl, 'moody');
+        parsed.imageWidth = meta.width;
+        parsed.imageHeight = meta.height;
+        parsed.imageMimeType = meta.mimeType;
+        parsed.imageAspectRatio = classifyAspectRatio(meta.width, meta.height, true, 0.05);
+      }
+
+      if (dryRun) console.log(`[DRY RUN] "${parsed.title}" (${parsed.sourceEventId})`);
+      else normalized.push(parsed);
+    } catch (err) {
+      const msg = `Failed to process event card: ${err}`;
+      console.error(`[moody] ${msg}`);
+      errors.push(msg);
+    }
+    await sleep(REQUEST_DELAY_MS);
+  }
+
+  if (!dryRun && normalized.length > 0) {
+    const result = await ingestEvents(env, normalized);
+    eventsUpserted = result.inserted + result.updated;
+    errors.push(...result.errors);
+  }
+
+  const durationMs = Date.now() - t0;
+  console.log(
+    `[moody] Finished in ${(durationMs / 1000).toFixed(1)}s — ${eventsUpserted} upserted, ${eventsSkipped} skipped, ${errors.length} errors`,
+  );
+  return {
+    eventsProcessed: selectedCards.length,
+    eventsUpserted,
+    eventsSkipped,
+    errors,
+    durationMs,
+  };
+}
+
+export async function run(env: Env): Promise<void> {
+  console.log('[moody] Scraper started');
+  await scrapeMoody(env);
+}

--- a/server/src/scrapers/registry.ts
+++ b/server/src/scrapers/registry.ts
@@ -16,6 +16,7 @@ import { run as runHornsLink, scrapeHornsLink } from './hornslink';
 import { run as runLawSchool, scrapeLawSchool } from './lawSchool';
 import { run as runLiberalArts, scrapeLiberalArts } from './liberalArts';
 import { run as runMccombs, scrapeMccombs } from './mccombs';
+import { run as runMoody, scrapeMoody } from './moody';
 import { run as runPharmacy } from './pharmacy';
 import { run as runTexasGlobal, scrapeTexasGlobal } from './texasGlobal';
 import { run as runTexasToday } from './texasToday';
@@ -31,6 +32,7 @@ export const SCRAPERS: ScraperEntry[] = [
   { name: 'hornslink', run: runHornsLink, manual: scrapeHornsLink },
   { name: 'texasToday', run: runTexasToday },
   { name: 'mccombs', run: runMccombs, manual: scrapeMccombs },
+  { name: 'moody', run: runMoody, manual: scrapeMoody },
   { name: 'texasGlobal', run: runTexasGlobal, manual: scrapeTexasGlobal },
   { name: 'lawSchool', run: runLawSchool, manual: scrapeLawSchool },
   { name: 'cola', run: runLiberalArts, manual: scrapeLiberalArts },

--- a/server/test/scrapers/test_moody.ts
+++ b/server/test/scrapers/test_moody.ts
@@ -18,6 +18,7 @@ function loadFixture(name: string): string {
   );
 }
 
+// Keep time-dependent filtering deterministic and earlier than fixture events.
 const NOW = new Date('2027-01-01T00:00:00Z').getTime();
 
 describe('Moody listing parser', () => {
@@ -94,6 +95,7 @@ describe('Moody detail parser', () => {
     };
     const event = parseMoodyEvent(secondOccurrence, detail, NOW);
     expect(event?.sourceEventId).toBe('student-screenwriting-festival::2027-04-01T17:00:00-05:00');
+    // The inherited three-hour duration ends at 8:00 pm CDT (01:00 UTC).
     expect(event?.endDatetime).toBe('2027-04-02T01:00:00.000Z');
   });
 

--- a/server/test/scrapers/test_moody.ts
+++ b/server/test/scrapers/test_moody.ts
@@ -1,0 +1,121 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import {
+  extractCategories,
+  extractEventCards,
+  extractSchemaEvent,
+  hasNextPage,
+  parseListingCard,
+  parseListingDatetime,
+  parseMoodyEvent,
+} from '../../src/scrapers/moody';
+
+function loadFixture(name: string): string {
+  return readFileSync(
+    join(__dirname, '..', '..', 'src', 'scrapers', '__fixtures__', 'moody', name),
+    'utf-8',
+  );
+}
+
+const NOW = new Date('2027-01-01T00:00:00Z').getTime();
+
+describe('Moody listing parser', () => {
+  it('extracts listing fields from saved Moody markup', () => {
+    const cards = extractEventCards(loadFixture('listing-page.html'));
+    expect(cards).toHaveLength(1);
+
+    const listing = parseListingCard(cards[0]);
+    expect(listing).toEqual({
+      slug: 'student-screenwriting-festival',
+      title: 'Student Screenwriting Festival',
+      description: 'A two-day festival for student filmmakers & writers.',
+      startDatetime: '2027-03-25T17:00:00-05:00',
+      eventUrl: 'https://events.moody.utexas.edu/events/student-screenwriting-festival',
+      imageUrl:
+        'https://events.moody.utexas.edu/sites/default/files/styles/large/public/2027-03/festival.png?itok=abc',
+      categories: ['Screening'],
+    });
+  });
+
+  it('handles a listing card with no image', () => {
+    const [card] = extractEventCards(loadFixture('last-page.html'));
+    expect(parseListingCard(card)?.imageUrl).toBeNull();
+  });
+
+  it('detects listing pagination', () => {
+    expect(hasNextPage(loadFixture('listing-page.html'))).toBe(true);
+    expect(hasNextPage(loadFixture('last-page.html'))).toBe(false);
+  });
+});
+
+describe('Moody detail parser', () => {
+  const detail = loadFixture('detail-page.html');
+  const listing = parseListingCard(extractEventCards(loadFixture('listing-page.html'))[0])!;
+
+  it('extracts structured event data and all rendered categories', () => {
+    expect(extractSchemaEvent(detail)?.endDate).toBe('2027-03-25T20:00:00-05:00');
+    expect(extractCategories(detail)).toEqual([
+      'Guest Speaker',
+      'Panel Discussion',
+      'Screening',
+      'Social',
+    ]);
+  });
+
+  it('maps the event into the shared schema', () => {
+    const event = parseMoodyEvent(listing, detail, NOW);
+    expect(event).not.toBeNull();
+    expect(event?.source).toBe('moody');
+    expect(event?.sourceEventId).toBe('student-screenwriting-festival::2027-03-25T17:00:00-05:00');
+    expect(event?.description).toBe('A two-day festival for student filmmakers and writers.');
+    expect(event?.startDatetime).toBe('2027-03-25T17:00:00-05:00');
+    expect(event?.endDatetime).toBe('2027-03-25T20:00:00-05:00');
+    expect(event?.locationFull).toBe('CMB 4.122 Studio 4C');
+    expect(event?.organization.name).toBe('Moody College of Communication');
+    expect(event?.rsvpUrl).toBe('https://example.com/register');
+    expect(event?.imageWidth).toBe(480);
+    expect(event?.imageHeight).toBe(480);
+    expect(event?.imageAspectRatio).toBe('square');
+    expect(event?.imageMimeType).toBe('image/png');
+    expect(event?.imageAltText).toBe('Students discussing screenplays');
+    expect(event?.categories).toEqual([
+      { id: 'guest-speaker', name: 'Guest Speaker' },
+      { id: 'panel-discussion', name: 'Panel Discussion' },
+      { id: 'screening', name: 'Screening' },
+      { id: 'social', name: 'Social' },
+    ]);
+  });
+
+  it('uses the occurrence start in the dedupe key for recurring events', () => {
+    const secondOccurrence = {
+      ...listing,
+      startDatetime: '2027-04-01T17:00:00-05:00',
+    };
+    const event = parseMoodyEvent(secondOccurrence, detail, NOW);
+    expect(event?.sourceEventId).toBe('student-screenwriting-festival::2027-04-01T17:00:00-05:00');
+    expect(event?.endDatetime).toBe('2027-04-02T01:00:00.000Z');
+  });
+
+  it('falls back to listing data when a detail page cannot be read', () => {
+    const event = parseMoodyEvent(listing, '', NOW);
+    expect(event?.description).toBe('A two-day festival for student filmmakers & writers.');
+    expect(event?.endDatetime).toBeNull();
+    expect(event?.categories).toEqual([{ id: 'screening', name: 'Screening' }]);
+  });
+
+  it('skips an occurrence that has already ended', () => {
+    expect(parseMoodyEvent(listing, detail, new Date('2028-01-01T00:00:00Z').getTime())).toBeNull();
+  });
+});
+
+describe('parseListingDatetime', () => {
+  it('applies CST and CDT based on the event date', () => {
+    expect(parseListingDatetime('January 8th, 2027 - 9:00 am')).toBe('2027-01-08T09:00:00-06:00');
+    expect(parseListingDatetime('July 8th, 2027 - 5:00 pm')).toBe('2027-07-08T17:00:00-05:00');
+  });
+
+  it('returns null for an invalid date label', () => {
+    expect(parseListingDatetime('Date TBA')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Cloudflare Worker scraper for the Moody College of Communication events calendar at `events.moody.utexas.edu`.

The scraper crawls the paginated upcoming-events listing, enriches each event from its detail page, maps records into the shared event schema, and uses the existing D1 ingestion pipeline for idempotent upserts.

Closes LOOP-229.

## Implementation

- Added `server/src/scrapers/moody.ts`
- Registered the `moody` scraper for scheduled and manual execution
- Added saved Moody HTML fixtures
- Added 10 unit tests covering listing parsing, detail enrichment, pagination, recurrence, and fallback behavior

## Extracted Fields

The scraper captures:

- Title
- Description
- Start and end datetimes
- Short and full location
- Host organization
- Event URL
- RSVP/website URL
- Image URL, dimensions, MIME type, and alt text
- Image aspect classification
- Event categories

## Pagination and Coverage

The scraper follows Drupal’s `rel="next"` pagination links until no subsequent page remains.

A 50-page safety cap prevents malformed pagination from creating an unbounded Worker execution. Runs also support the repository-standard `maxEvents` and `dryRun` options.

## Detail Enrichment

Listing cards provide each occurrence’s identity, title, summary, start time, image, and primary category.

Detail pages provide additional data through embedded Schema.org JSON-LD and rendered fields, including:

- Full description
- End time
- Location
- Image dimensions
- Image alt text
- Complete category list
- Registration or website URL

If a detail-page request fails, the scraper continues using the listing data instead of dropping the event.

## Recurring Events and Deduplication

Moody reuses the same event URL for multiple occurrences of a recurring event.

To keep occurrences distinct while preventing duplicates across repeat runs, the scraper uses `{event-slug}::{start-datetime}` as `source_event_id`.

Moody’s JSON-LD can describe the first occurrence even when the listing points to a later occurrence. In that case, the scraper preserves the listing’s authoritative start time and applies the duration from JSON-LD to calculate the corresponding end time.

D1 upserts continue to use the existing unique `(source, source_event_id)` constraint.

## Host Organization

Moody exposes an “Event Host” filter but does not render the selected host taxonomy on listing cards or event detail pages.

To avoid roughly 30 additional filtered listing crawls per run, all Moody events use `Moody College of Communication` as the host organization.

This is an intentional fallback selected for reliability and lower request volume.

## Image Handling

When JSON-LD provides image dimensions, the scraper uses them directly and classifies the image as:

- `vertical`
- `square`
- `horizontal`
- `none`

If dimensions are missing, the scraper uses the shared range-request image metadata helper to inspect the image header without downloading the full asset.

## Error Isolation

Failures are isolated at multiple levels:

- A listing discovery failure returns a structured fatal error
- A detail-page failure falls back to listing data
- An individual parsing or image failure does not stop other events
- The shared ingestion layer isolates individual D1 upsert failures

## Test Coverage

Added fixture-backed coverage for:

- Listing-card extraction
- Listing field normalization
- Pages with and without a next-page link
- Events without images
- CST and CDT timestamp conversion
- JSON-LD extraction
- Multiple rendered categories
- Shared-schema mapping
- Image dimensions and aspect classification
- Recurring-event deduplication
- Detail-page fallback behavior
- Filtering completed events

## Verification

- Server TypeScript build passed
- Full server suite passed: 288 tests
- Moody scraper suite passed: 10 tests
- Prettier check passed
- Root lint passed with no errors

The root application typecheck still reports existing Expo Router typed-route errors in unrelated profile, settings, and organization files. This PR does not modify those files.

## Notes

No database migration is required. The scraper uses the existing normalized event schema and shared D1 ingestion/upsert implementation.