### PR TITLE
Feature/bugbash prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,22 +72,37 @@ Join our community of developers creating universal apps.
 
 ## Starting the Server
 
-1. Open a 2nd terminal window while keeping the client terminal open
+The backend is a Cloudflare Worker, not a plain Node server. In development
+`app/config/api.ts` points the app at whichever machine started Expo, on port
+8787 — so the Worker has to be running locally or every request fails.
 
-2. Cd into the /server directory
+1. Open a second terminal, keeping the one running Expo open.
+
+2. Set it up (once):
 
    ```bash
    cd server
+   npm install
+   cp .dev.vars.example .dev.vars
+   npx wrangler d1 execute loop-db --local --file=schema.sql
    ```
 
-3. Install dependencies
+   `.dev.vars` is git-ignored and its defaults work as-is. That includes
+   `RESEND_DEV_MODE=true`, which prints verification codes to this terminal
+   instead of emailing them — so you can sign in without a Resend account.
+
+   The `d1 execute` line builds your own local SQLite copy of the database.
+   Nothing you do locally touches production.
+
+3. Start it:
 
    ```bash
-   npm install express cors dotenv
+   npm run dev:lan
    ```
 
-4. Start the server with the /server directory
+   `dev:lan` binds to `0.0.0.0` so a real phone on your wifi can reach it.
+   `npm run dev` binds to localhost only, which is fine for Expo web and the
+   iOS simulator but unreachable from a device.
 
-   ```bash
-   npm run dev
-   ```
+See [`server/README.md`](server/README.md) for the rest — resetting the local
+database, running migrations, and deploying.

--- a/app/(onboarding)/TermsAndConditions.tsx
+++ b/app/(onboarding)/TermsAndConditions.tsx
@@ -7,7 +7,7 @@ import FlowLayout from '../components/layouts/FlowLayout';
 const TERMS = [
   {
     id: 'responsible',
-    label: 'I agree to use Longhorn Journey responsibly and not post misleading or troll content.',
+    label: 'I agree to use Longhorn Loop responsibly and not post misleading or troll content.',
   },
   {
     id: 'visible',
@@ -17,7 +17,18 @@ const TERMS = [
     id: 'guidelines',
     label: 'I agree to respect the community guidelines and other users.',
   },
-];
+  {
+    id: 'removed',
+    label:
+      'I acknowledge that violating the guidelines may result in my removal and a permanent ban.',
+  },
+] as const;
+
+/** Every box starts unchecked. Derived from TERMS so the two cannot disagree —
+ *  see the note on `allChecked`. */
+const NONE_CHECKED: Record<string, boolean> = Object.fromEntries(
+  TERMS.map((term) => [term.id, false]),
+);
 
 /**
  * The checkbox was a 16pt square with a 12pt label beside it, which is the
@@ -32,13 +43,14 @@ const ROW_MIN_HEIGHT = 48;
 
 export default function TermsAndConditions() {
   const router = useRouter();
-  const [checked, setChecked] = useState<Record<string, boolean>>({
-    responsible: false,
-    visible: false,
-    guidelines: false,
-  });
+  const [checked, setChecked] = useState<Record<string, boolean>>(NONE_CHECKED);
 
-  const allChecked = Object.values(checked).every(Boolean);
+  // Over TERMS, not over the keys of `checked`. Those are not the same set: a
+  // term nobody has tapped yet has no key, so `Object.values(checked).every()`
+  // is asking "is everything I have seen ticked", which is true of an empty
+  // object and true of three ticks out of four. Adding a fourth term to the
+  // list is exactly how you would hit that, and it is what happened here.
+  const allChecked = TERMS.every((term) => checked[term.id]);
 
   const toggleCheckbox = (id: string) => {
     setChecked((prev) => ({ ...prev, [id]: !prev[id] }));

--- a/server/package.json
+++ b/server/package.json
@@ -14,19 +14,11 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "cors": "^2.8.6",
-    "dotenv": "^17.3.1",
-    "express": "^5.2.1",
-    "hono": "^4.12.26",
-    "jsonwebtoken": "^9.0.3"
+    "hono": "^4.12.26"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260415.1",
-    "@types/cors": "^2.8.19",
-    "@types/express": "^5.0.6",
-    "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.5.0",
-    "ts-node-dev": "^2.0.0",
     "typescript": "^5.9.3",
     "vitest": "^2.1.9",
     "wrangler": "^4.83.0"


### PR DESCRIPTION
## Terms screen: fourth term, and the gate that was ignoring it

Adds a term about removal and permanent bans, and fixes "Longhorn Journey" —
the old product name was still on the one screen every account passes through.

The new term exposed a bug. `checked` was seeded with the three ids written out
by hand, and the gate was `Object.values(checked).every(Boolean)`. A term nobody
has tapped yet has no key in that object, so `every` was asking "is everything
I have seen so far ticked" — true of three ticks out of four. Tick the original
three and Next enables while the ban clause sits unchecked.

Both sides now derive from `TERMS`, so a fifth term cannot reintroduce it.

## README: the setup steps the Express removal invalidated

The root README still said `npm install express cors dotenv` then `npm run dev`.
`npm run dev` starts `wrangler dev` now, those packages are unused, and the
instructions omit both things the Worker needs — `.dev.vars` and a local D1
database. A new contributor ends up with a Worker running against nothing.

Also drops express, cors, dotenv and jsonwebtoken from server dependencies plus
their @types and ts-node-dev. Nothing has imported them since the Express stack
was deleted; `hono` is the only runtime dependency left. No reinstall needed —
they are removals.