### PR TITLE
Let people run the server without a Cloudflare account

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ The backend is a Cloudflare Worker, not a plain Node server. In development
    instead of emailing them — so you can sign in without a Resend account.
 
    The `d1 execute` line builds your own local SQLite copy of the database.
-   Nothing you do locally touches production.
+   Nothing you do locally touches production, and you do not need a Cloudflare
+   account — the dev scripts run against `[env.local]`, which leaves out the two
+   bindings that would otherwise require one.
 
 3. Start it:
 

--- a/server/README.md
+++ b/server/README.md
@@ -18,13 +18,44 @@ npm run dev:lan
 Worker is now running on port 8787. The app's `app/config/api.ts` points at it
 automatically in dev mode, so `npx expo start` in the repo root just works.
 
-### Why `dev:lan` and not `wrangler dev`
+You do not need a Cloudflare account to do any of this. Everything above runs
+against a SQLite file on your own machine.
 
-`wrangler dev` binds to localhost only, which is fine for the iOS simulator and
-Expo web (same machine) but unreachable from a real phone. `npm run dev:lan`
-adds `--ip 0.0.0.0` so the Worker also accepts connections from other devices
-on your network. Use `npm run dev:worker` if you specifically want the
-localhost-only bind.
+### The dev scripts
+
+| script              | what it does                                                |
+| ------------------- | ----------------------------------------------------------- |
+| `npm run dev`       | `--env local`, localhost only. Simulator and Expo web.      |
+| `npm run dev:lan`   | `--env local`, `--ip 0.0.0.0`. Also reachable from a phone. |
+| `npm run dev:cloud` | Full config, remote bindings. Needs Cloudflare access.      |
+
+`dev` binds to localhost, which is the phone itself when you open the app on a
+real device — nothing is listening there, so every request fails. `dev:lan`
+binds to `0.0.0.0` so other devices on your wifi can reach it.
+
+### Why `--env local` exists
+
+Workers AI and Vectorize have no local emulation. When wrangler sees the
+top-level `[ai]` and `[[vectorize]]` bindings it opens a _remote proxy session_
+against the Longhorn Developers Cloudflare account before serving a single
+request, so plain `wrangler dev` fails for anyone not signed in to it:
+
+```
+[ERROR] A request to the Cloudflare API (/accounts/9f38.../workers/subdomain/edge-preview) failed.
+[ERROR] Failed to start the remote proxy session.
+```
+
+Those two bindings are only used by the ingest path — semantic tagging of
+scraped events, which runs on a cron. Nothing a person clicks in the app touches
+them, and every call site already handles the binding being absent. So
+`[env.local]` in `wrangler.toml` leaves them out and local dev stays offline.
+
+Use `dev:cloud` if you are specifically working on ingest or semantic tagging;
+that one does need an account.
+
+Bindings are not inherited by named environments in wrangler, so `[env.local]`
+repeats `DB`, `EVENT_IMAGES` and the vars. If you add a binding the app needs at
+request time, add it in both places.
 
 ## Testing on a physical phone
 

--- a/server/package.json
+++ b/server/package.json
@@ -4,10 +4,10 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "vitest run",
-    "dev": "wrangler dev",
-    "dev:worker": "wrangler dev",
-    "dev:lan": "wrangler dev --ip 0.0.0.0",
-    "build": "tsc"
+    "dev": "wrangler dev --env local",
+    "dev:lan": "wrangler dev --env local --ip 0.0.0.0",
+    "build": "tsc",
+    "dev:cloud": "wrangler dev"
   },
   "keywords": [],
   "author": "",

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -64,3 +64,45 @@ EMAIL_PROVIDER = "resend"
 # EMAIL_PROVIDER = "cloudflare". Requires the Workers Paid plan.
 # [[send_email]]
 # name = "EMAIL"
+
+# ---------------------------------------------------------------------------
+# Local development environment: `wrangler dev --env local`, via `npm run dev`.
+#
+# WHY THIS EXISTS
+#
+# Workers AI and Vectorize have no local emulation. When wrangler sees the
+# top-level [ai] and [[vectorize]] bindings it opens a "remote proxy session"
+# against this account before it will serve a single request, so `wrangler dev`
+# fails outright for anyone not signed in to the Longhorn Developers Cloudflare
+# account:
+#
+#   [ERROR] A request to the Cloudflare API
+#           (/accounts/9f38.../workers/subdomain/edge-preview) failed.
+#   [ERROR] Failed to start the remote proxy session.
+#
+# Those two bindings are only used by the ingest path — semantic tagging of
+# scraped events, which runs on a cron. Nothing a person clicks in the app
+# touches them, and every call site already guards on the binding being absent
+# (see lib/semanticTags.ts and lib/utils.ts, which return null or a no-op
+# result). So local dev drops them and stays entirely offline.
+#
+# Bindings are NOT inherited by named environments in wrangler — that is a
+# footgun most of the time and exactly what we want here, but it does mean DB,
+# R2 and vars have to be repeated below. If you add a binding above that the
+# app needs at request time, add it here too.
+# ---------------------------------------------------------------------------
+[env.local]
+
+[[env.local.d1_databases]]
+binding = "DB"
+database_name = "loop-db"
+database_id = "dc2be36a-b3b9-45a5-9fc8-fb223eb336bf"
+
+[[env.local.r2_buckets]]
+binding = "EVENT_IMAGES"
+bucket_name = "longhorn-loop-event-images"
+
+[env.local.vars]
+EVENT_IMAGE_PUBLIC_BASE_URL = "https://pub-1fa687f6640643bc900bbbc25e3aba0c.r2.dev"
+EMAIL_FROM = "Longhorn Loop <noreply@longhorndevelopers.org>"
+EMAIL_PROVIDER = "resend"


### PR DESCRIPTION
`npm run dev:lan` failed for anyone not signed in to the Longhorn Developers Cloudflare account:

    [ERROR] A request to the Cloudflare API
            (/accounts/9f38.../workers/subdomain/edge-preview) failed.
    [ERROR] Failed to start the remote proxy session.

Workers AI and Vectorize have no local emulation, so wrangler opens a remote proxy session against the account before serving a single request. The failure has nothing to do with what you are working on — it stops the Worker starting at all, and the error names an internal Cloudflare endpoint rather than the actual problem, so it does not lead anywhere useful.

Both bindings exist only for the ingest path: semantic tagging of scraped events, on a cron. Nothing a person clicks in the app reaches them, and every call site already returns null or a no-op when the binding is absent (lib/semanticTags.ts, lib/utils.ts) — the code was written for this, we just never had a config that used it.

So `[env.local]` drops [ai] and [[vectorize]], and `dev` / `dev:lan` point at it. Local dev is now entirely offline: no login, no account membership, no org quota spent on a UI change. `dev:cloud` keeps the full config for whoever is actually working on ingest.

Verified by running `wrangler dev --env local` unauthenticated: the Worker starts, GET /events reads the local D1, and POST /auth/send-code returns 200 with the code printed to the terminal.

Bindings are not inherited by named environments in wrangler, so [env.local] repeats DB, EVENT_IMAGES and the vars. Both READMEs say so, and say to add a binding in both places.

Also drops dev:worker, which did the same thing as dev.