### PR TITLE
Feature/local dev env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,34 @@
+# Copy to `.env` to point the app somewhere other than the default.
+# `.env` is git-ignored; this file is the template.
+#
+# Leave everything commented out and the app follows app/config/api.ts:
+# in development it talks to `wrangler dev` on the machine that started Expo,
+# and in a release build it talks to the deployed Worker.
+
+# ---------------------------------------------------------------------------
+# EXPO_PUBLIC_API_BASE_URL — which backend the app talks to.
+# ---------------------------------------------------------------------------
+#
+# Uncomment this to skip running the server locally and use the deployed
+# Worker instead. You then do NOT need wrangler, a local database, or a
+# Cloudflare account — and verification codes arrive in a real inbox rather
+# than printing to a terminal, which is what a beta tester will experience.
+#
+# The trade-off is that everything you do lands in the PRODUCTION database.
+# Accounts you create and events you post are real and other people will see
+# them. Fine for a bug bash, not for experimenting.
+#
+# EXPO_PUBLIC_API_BASE_URL=https://loop-db.longhorn-developers.workers.dev
+
+# Point at a teammate's machine instead (they run `npm run dev:lan`):
+# EXPO_PUBLIC_API_BASE_URL=http://192.168.1.24:8787
+
+# ---------------------------------------------------------------------------
+# EXPO_PUBLIC_SENTRY_DSN — crash reporting. Currently unused: lib/monitoring.ts
+# is a no-op until the Metro resolution issue with @sentry/react is fixed.
+# ---------------------------------------------------------------------------
+# EXPO_PUBLIC_SENTRY_DSN=
+
+# Anything prefixed EXPO_PUBLIC_ is inlined into the JS bundle at build time.
+# Never put a secret here — it ships to every device. Server secrets belong in
+# server/.dev.vars locally, and in `wrangler secret put` in production.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,33 @@ Join our community of developers creating universal apps.
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
 
+## Pointing the app at a backend
+
+There are two ways to run, and which you want depends on what you are testing.
+
+**Local backend** (default). You run the Worker yourself; verification codes
+print to your terminal. Nothing you do leaves your machine. Best for
+day-to-day work — see _Starting the Server_ below.
+
+**Deployed backend.** Copy `.env.example` to `.env` and uncomment the
+production line:
+
+```
+EXPO_PUBLIC_API_BASE_URL=https://loop-db.longhorn-developers.workers.dev
+```
+
+Now you need no wrangler, no local database, and no Cloudflare account —
+`npx expo start` on its own is the whole setup. Verification codes arrive in a
+real inbox, which is what a beta tester experiences, so this is the mode for
+testing the flow end to end.
+
+The catch: you are writing to the **production database**. Accounts you create
+and events you post are real, and other people will see them. Good for a bug
+bash, bad for experimenting.
+
+`.env` is git-ignored, and a non-https override is refused in release builds,
+so a stray local `.env` cannot ship pointing at someone's laptop.
+
 ## Starting the Server
 
 The backend is a Cloudflare Worker, not a plain Node server. In development

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ The backend is a Cloudflare Worker, not a plain Node server. In development
    npx wrangler d1 execute loop-db --local --file=schema.sql
    ```
 
-   `.dev.vars` is git-ignored and its defaults work as-is. That includes
-   `RESEND_DEV_MODE=true`, which prints verification codes to this terminal
-   instead of emailing them — so you can sign in without a Resend account.
+   `.dev.vars` is git-ignored and its defaults work as-is. It is optional now —
+   `[env.local]` already sends verification codes to this terminal rather than
+   to an inbox, so you can sign in without it. Copy it anyway if you want to
+   set a real `RESEND_API_KEY` or the R2 image base URL.
 
    The `d1 execute` line builds your own local SQLite copy of the database.
    Nothing you do locally touches production, and you do not need a Cloudflare

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -93,10 +93,15 @@ EMAIL_PROVIDER = "resend"
 # ---------------------------------------------------------------------------
 [env.local]
 
+# The id is deliberately not the real one. `--local` keys its SQLite file off
+# it and never validates it, so local dev is unaffected — but it means a
+# stray `wrangler deploy --env local` fails on an invalid database id instead
+# of quietly standing up a second Worker wired to the PRODUCTION database.
+# We have already had one orphaned Worker firing crons at prod; once is enough.
 [[env.local.d1_databases]]
 binding = "DB"
 database_name = "loop-db"
-database_id = "dc2be36a-b3b9-45a5-9fc8-fb223eb336bf"
+database_id = "local-only-never-deploy"
 
 [[env.local.r2_buckets]]
 binding = "EVENT_IMAGES"
@@ -105,4 +110,7 @@ bucket_name = "longhorn-loop-event-images"
 [env.local.vars]
 EVENT_IMAGE_PUBLIC_BASE_URL = "https://pub-1fa687f6640643bc900bbbc25e3aba0c.r2.dev"
 EMAIL_FROM = "Longhorn Loop <noreply@longhorndevelopers.org>"
-EMAIL_PROVIDER = "resend"
+# 'dev', not 'resend': codes print to the wrangler console. Local dev cannot
+# send real mail even if someone has a live RESEND_API_KEY in their .dev.vars,
+# which matters while the account is on a 100/day free tier that the beta needs.
+EMAIL_PROVIDER = "dev"


### PR DESCRIPTION
Follow-up to #373. Two commits, both config.

## 1. `[env.local]` can't touch production

The D1 id there is now a placeholder. `--local` keys its SQLite file off that
string and never validates it, so local dev is unaffected — verified with a
full sign-in round trip. What changes is the failure mode of a mistake:
`wrangler deploy --env local` now dies on an invalid database id instead of
quietly standing up a second Worker, named `loop-db-local`, wired to the
PRODUCTION database and carrying no crons. We have already found one orphaned
Worker firing crons at prod on 52-day-old code.

`EMAIL_PROVIDER` is `"dev"` rather than `"resend"`, so local dev cannot send
real mail even with a live `RESEND_API_KEY` in someone's `.dev.vars` — the
account is capped at 100 sends/day and beta invites come from the same pool.

Side effect: sign-in now works with no `.dev.vars` file at all. `send-code`
prints the code, `verify-code` returns a token.

## 2. `.env.example`

`app/config/api.ts` has always honoured `EXPO_PUBLIC_API_BASE_URL` in dev, but
nothing in the repo said so, so the only documented path was the local one.
Uncomment one line and the app talks to the deployed Worker instead: no
wrangler, no local database, no Cloudflare account, and verification codes
arrive in a real inbox — what a beta tester actually experiences.

The file states plainly that this writes to the production database.

`wrangler deploy` with no `--env` is unchanged.