### PR TITLE
Default to the deployed backend, so a fresh clone just works

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,46 @@
-# Copy to `.env` to point the app somewhere other than the default.
+# Copy to `.env` ONLY if you need to change where the app sends its requests.
 # `.env` is git-ignored; this file is the template.
 #
-# Leave everything commented out and the app follows app/config/api.ts:
-# in development it talks to `wrangler dev` on the machine that started Expo,
-# and in a release build it talks to the deployed Worker.
+# You almost certainly do not need this file. Out of the box — a fresh clone,
+# `npm install`, `npx expo start` — the app talks to the deployed Worker. No
+# wrangler, no local database, no Cloudflare account, and verification codes
+# arrive in a real inbox, which is what a beta tester experiences.
+#
+# The default writes to the PRODUCTION database. Accounts you create and
+# events you post are real and other people see them. If you are experimenting
+# rather than testing, use the local flag below.
+#
+# On startup the app prints which backend it chose, e.g.
+#   [api] https://loop-db.longhorn-developers.workers.dev  (default)
 
 # ---------------------------------------------------------------------------
-# EXPO_PUBLIC_API_BASE_URL — which backend the app talks to.
+# Run the backend on this machine instead.
 # ---------------------------------------------------------------------------
 #
-# Uncomment this to skip running the server locally and use the deployed
-# Worker instead. You then do NOT need wrangler, a local database, or a
-# Cloudflare account — and verification codes arrive in a real inbox rather
-# than printing to a terminal, which is what a beta tester will experience.
+# Requires `npm run dev:lan` in server/ — see server/README.md. Verification
+# codes then print to that terminal instead of being emailed. The app works
+# out which address to use, including from a real phone on your wifi.
 #
-# The trade-off is that everything you do lands in the PRODUCTION database.
-# Accounts you create and events you post are real and other people will see
-# them. Fine for a bug bash, not for experimenting.
-#
-# EXPO_PUBLIC_API_BASE_URL=https://loop-db.longhorn-developers.workers.dev
+# EXPO_PUBLIC_USE_LOCAL_API=1
 
-# Point at a teammate's machine instead (they run `npm run dev:lan`):
+# ---------------------------------------------------------------------------
+# Or point at one exact URL. Wins over everything above.
+# ---------------------------------------------------------------------------
+#
+# A teammate's machine, a tunnel, a future staging Worker. No trailing slash —
+# the app appends its own paths (a trailing slash is trimmed anyway).
+#
 # EXPO_PUBLIC_API_BASE_URL=http://192.168.1.24:8787
 
 # ---------------------------------------------------------------------------
-# EXPO_PUBLIC_SENTRY_DSN — crash reporting. Currently unused: lib/monitoring.ts
-# is a no-op until the Metro resolution issue with @sentry/react is fixed.
+# Crash reporting. Currently unused: lib/monitoring.ts is a no-op until the
+# Metro resolution issue with @sentry/react is fixed.
 # ---------------------------------------------------------------------------
 # EXPO_PUBLIC_SENTRY_DSN=
 
 # Anything prefixed EXPO_PUBLIC_ is inlined into the JS bundle at build time.
 # Never put a secret here — it ships to every device. Server secrets belong in
 # server/.dev.vars locally, and in `wrangler secret put` in production.
+#
+# Because it is inlined at BUILD time, editing this file while Metro is running
+# does nothing. Restart with `npx expo start --clear` and reload the app.

--- a/README.md
+++ b/README.md
@@ -72,30 +72,26 @@ Join our community of developers creating universal apps.
 
 ## Pointing the app at a backend
 
-There are two ways to run, and which you want depends on what you are testing.
+Nothing to configure. A fresh clone plus `npm install` and `npx expo start`
+talks to the deployed Worker — no wrangler, no local database, no Cloudflare
+account. Verification codes arrive in your real UT inbox, which is what a beta
+tester experiences.
 
-**Local backend** (default). You run the Worker yourself; verification codes
-print to your terminal. Nothing you do leaves your machine. Best for
-day-to-day work — see _Starting the Server_ below.
-
-**Deployed backend.** Copy `.env.example` to `.env` and uncomment the
-production line:
+On startup the app prints which backend it picked:
 
 ```
-EXPO_PUBLIC_API_BASE_URL=https://loop-db.longhorn-developers.workers.dev
+[api] https://loop-db.longhorn-developers.workers.dev  (default)
 ```
 
-Now you need no wrangler, no local database, and no Cloudflare account —
-`npx expo start` on its own is the whole setup. Verification codes arrive in a
-real inbox, which is what a beta tester experiences, so this is the mode for
-testing the flow end to end.
+**This writes to the production database.** Accounts you create and events you
+post are real and other people will see them. That is the right default while
+the team is testing flows end to end, and the wrong one if you are
+experimenting — run the backend locally for that (below), which needs
+`EXPO_PUBLIC_USE_LOCAL_API=1` in a `.env`. See `.env.example`.
 
-The catch: you are writing to the **production database**. Accounts you create
-and events you post are real, and other people will see them. Good for a bug
-bash, bad for experimenting.
-
-`.env` is git-ignored, and a non-https override is refused in release builds,
-so a stray local `.env` cannot ship pointing at someone's laptop.
+`EXPO_PUBLIC_*` is inlined into the bundle at build time, so after editing
+`.env` you must restart with `npx expo start --clear` **and** reload the app.
+Editing it with Metro running has no effect.
 
 ## Starting the Server
 

--- a/app/config/api.ts
+++ b/app/config/api.ts
@@ -1,16 +1,36 @@
 // Where the app sends its API calls.
 //
-// Production hits the deployed Worker. Development has to reach the
-// `wrangler dev` process on whichever machine started Expo, and the address
-// that machine answers to depends on where the app is running:
+// THE DEFAULT IS THE DEPLOYED WORKER, IN DEVELOPMENT TOO.
+//
+// It used to be a local `wrangler dev`, which quietly required five things to
+// be true before `npx expo start` did anything: npm install in server/, a
+// .dev.vars file, a seeded local D1, a Cloudflare account, and a second
+// terminal left running. Miss any one and the app says "Network error: please
+// check your connection", which sends people to look at their wifi. That cost
+// a whole bug bash morning across several people.
+//
+// Almost nobody working on a screen needs a local Worker. So `git pull` and
+// `npx expo start` now work with no setup at all, and running the server
+// locally is the thing you opt into:
+//
+//   EXPO_PUBLIC_USE_LOCAL_API=1     talk to `wrangler dev` on this machine
+//   EXPO_PUBLIC_API_BASE_URL=...    talk to this exact URL (wins over both)
+//
+// The trade-off is real and worth saying out loud: the default writes to the
+// PRODUCTION database. Accounts you create and events you post are visible to
+// everyone. That is the right default while the whole team is testing flows
+// against real email, and the wrong one if you are experimenting — use the
+// local flag then.
+//
+// Whichever it picks, it says so in the Metro console on startup.
+//
+// Reaching a local Worker is itself awkward, which is why devApiBaseUrl exists:
 //
 //   Expo web, iOS simulator   "localhost" is the same machine — works
 //   A real phone in Expo Go   "localhost" is the *phone* — nothing is
 //                             listening there, so every request fails
 //
-// This file used to hardcode localhost in dev, which is exactly why the app
-// worked in a browser and threw "Network request failed" on phones. We now
-// read the dev machine's address out of the Expo host URI: it's the same host
+// So we read the dev machine's address out of the Expo host URI: the same host
 // Metro just served the JS bundle from, so if the app opened at all, this
 // resolves to something reachable.
 
@@ -59,9 +79,28 @@ function devApiBaseUrl(): string {
   return `http://${host}:${DEV_API_PORT}`;
 }
 
-// An explicit override wins in dev. Set EXPO_PUBLIC_API_BASE_URL in .env to
-// point a device at the deployed Worker, a tunnel, or a teammate's machine.
-const override = process.env.EXPO_PUBLIC_API_BASE_URL;
+/**
+ * Trim whitespace and any trailing slashes off a base URL.
+ *
+ * Every caller writes `${API_BASE_URL}/auth/send-code`, so a base ending in
+ * "/" produces "https://host//auth/send-code". Hono does not match a doubled
+ * slash, so every request 404s and the app reports a network error — which
+ * points at the wifi rather than at the one character that is wrong. Not
+ * hypothetical: the value gets copied out of a browser address bar, and
+ * browsers show the trailing slash.
+ */
+function normalizeBaseUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().replace(/\/+$/, '');
+  return trimmed ? trimmed : undefined;
+}
+
+/** An exact URL to talk to. Wins over everything, in dev and (over https) in
+ *  release. A teammate's machine, a tunnel, a staging Worker. */
+const override = normalizeBaseUrl(process.env.EXPO_PUBLIC_API_BASE_URL);
+
+/** Opt in to the `wrangler dev` running on this machine. Accepts "1" or "true"
+ *  because both are what people type. */
+const useLocalApi = /^(1|true)$/i.test(process.env.EXPO_PUBLIC_USE_LOCAL_API?.trim() ?? '');
 
 /**
  * EXPO_PUBLIC_* values are inlined into the bundle at build time, so a `.env`
@@ -83,6 +122,33 @@ function overrideForRelease(value: string | undefined): string | undefined {
   return undefined;
 }
 
+function resolveDevBaseUrl(): string {
+  if (override) return override;
+  if (useLocalApi) return devApiBaseUrl();
+  return PROD_API;
+}
+
 export const API_BASE_URL = __DEV__
-  ? override || devApiBaseUrl()
+  ? resolveDevBaseUrl()
   : overrideForRelease(override) || PROD_API;
+
+// Say which backend this bundle is talking to, and why.
+//
+// Every confusing hour this file has caused came down to not knowing that.
+// EXPO_PUBLIC_* is inlined at BUILD time, so an edited .env with no `--clear`
+// and no app reload silently keeps the old value — and the only symptom is a
+// network error that looks like a connectivity problem.
+if (__DEV__) {
+  const reason = override
+    ? 'EXPO_PUBLIC_API_BASE_URL'
+    : useLocalApi
+      ? 'EXPO_PUBLIC_USE_LOCAL_API=1'
+      : 'default';
+
+  console.log(
+    `[api] ${API_BASE_URL}  (${reason})` +
+      (override || useLocalApi
+        ? ''
+        : '  — production database; set EXPO_PUBLIC_USE_LOCAL_API=1 for a local Worker'),
+  );
+}

--- a/server/README.md
+++ b/server/README.md
@@ -15,8 +15,25 @@ npx wrangler d1 execute loop-db --local --file=schema.sql
 npm run dev:lan
 ```
 
-Worker is now running on port 8787. The app's `app/config/api.ts` points at it
-automatically in dev mode, so `npx expo start` in the repo root just works.
+Worker is now running on port 8787. One more step: the app talks to the
+**deployed** Worker by default, so tell it to use yours instead. In the repo
+root:
+
+```bash
+echo "EXPO_PUBLIC_USE_LOCAL_API=1" >> .env
+npx expo start --clear
+```
+
+It works out the right address on its own, including from a real phone on your
+wifi. On startup it prints which backend it chose:
+
+```
+[api] http://192.168.1.24:8787  (EXPO_PUBLIC_USE_LOCAL_API=1)
+```
+
+If that line says `(default)` and a workers.dev URL, the flag did not take —
+`EXPO_PUBLIC_*` is inlined at build time, so `.env` edits need `--clear` and an
+app reload.
 
 You do not need a Cloudflare account to do any of this. Everything above runs
 against a SQLite file on your own machine.


### PR DESCRIPTION
`git pull && npx expo start` did not work. It quietly required five things to be true first: npm install in server/, a .dev.vars file, a seeded local D1, a Cloudflare account, and a second terminal left running. Miss any one and the app says

    Network error: Please check your connection.

which sends people to look at their wifi. Between that and a `.env` that has to be at the repo root, spelled right, with no trailing slash, and picked up by a Metro restart, this cost several people most of a bug bash morning.

Almost nobody working on a screen needs a local Worker. So the default in development is now the deployed Worker — the same one beta testers reach — and running the server locally is what you opt into:

    EXPO_PUBLIC_USE_LOCAL_API=1     talk to `wrangler dev` on this machine
    EXPO_PUBLIC_API_BASE_URL=...    talk to this exact URL, wins over both

A fresh clone plus `npm install` and `npx expo start` now needs no configuration at all, and codes arrive in a real inbox.

The cost is that the default writes to the production database. That is the right trade while the whole team is testing flows against real email, and it is stated plainly in .env.example and both READMEs rather than left to be discovered.

Two things that would have saved the morning on their own:

- The app now logs which backend it resolved and why, on every dev start: [api] https://loop-db.longhorn-developers.workers.dev  (default) EXPO_PUBLIC_* is inlined at BUILD time, so an edited .env with no --clear and no app reload silently keeps the old value. The only symptom was a network error indistinguishable from being offline.

- A trailing slash on the override is now trimmed. Callers write `${API_BASE_URL}/auth/send-code`, so ".../" produced a doubled slash that Hono does not match — every request 404s. The value gets copied out of a browser address bar, and browsers show the trailing slash.

server/README.md said `npx expo start` "just works" once wrangler is running. That is no longer true, so it now says to set the flag.

Supersedes api-base-url-trailing-slash.patch, which is folded in here.